### PR TITLE
Translate Quint `generate`

### DIFF
--- a/.unreleased/features/translate-generate.md
+++ b/.unreleased/features/translate-generate.md
@@ -1,0 +1,1 @@
+Translate Quint's generate into `Apalache!Gen` (#2916)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -667,15 +667,15 @@ class Quint(quintOutput: QuintOutput) {
         tlaScope <- tlaExpression(scope)
       } yield tla.exists(tlaName, tlaDomain, tlaScope)
 
-    case (QuintDef.QuintOpDef(_, name, "nondet", QuintApp(id, "generate", Seq(bound))), scope) =>
-      val elemType = typeConv.convert(types(id).typ)
+    case (QuintDef.QuintOpDef(_, name, "nondet", QuintApp(id, "generate", Seq(_, bound))), scope) =>
+      val setType = typeConv.convert(types(id).typ)
       val boundIntConst = intFromExpr(bound)
       if (boundIntConst.isEmpty) {
         throw new QuintIRParseError(s"nondet $name = generate($bound) ... expects an integer constant")
       }
       for {
         tlaScope <- tlaExpression(scope)
-      } yield tla.letIn(tlaScope, tla.decl(name, tla.gen(boundIntConst.get, elemType)))
+      } yield tla.letIn(tlaScope, tla.decl(name, tla.gen(boundIntConst.get, setType)))
 
     case invalidValue =>
       throw new QuintIRParseError(s"nondet keyword used to bind invalid value ${invalidValue}")

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -173,7 +173,7 @@ class TestQuintEx extends AnyFunSuite {
     val oneOfSet = app("oneOf", intSet)(QuintIntT())
     val nondetBinding =
       e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", oneOfSet), QuintIntT()), nIsGreaterThan0), QuintBoolT())
-    val generateSet = app("generate", _42)(QuintSetT(QuintIntT()))
+    val generateSet = app("generate", _42, _42)(QuintSetT(QuintIntT()))
     val nondetGenerate =
       e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", generateSet), QuintIntT()), tt), QuintBoolT())
     // Requires ID registered with type

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -172,7 +172,10 @@ class TestQuintEx extends AnyFunSuite {
     val chooseSomeFromIntSet = app("chooseSome", intSet)(QuintIntT())
     val oneOfSet = app("oneOf", intSet)(QuintIntT())
     val nondetBinding =
-      e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", oneOfSet), QuintIntT()), nIsGreaterThan0), QuintIntT())
+      e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", oneOfSet), QuintIntT()), nIsGreaterThan0), QuintBoolT())
+    val generateSet = app("generate", _42)(QuintSetT(QuintIntT()))
+    val nondetGenerate =
+      e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", generateSet), QuintIntT()), tt), QuintBoolT())
     // Requires ID registered with type
     val selectGreaterThanZero = app("select", intList, intIsGreaterThanZero)(QuintSeqT(QuintIntT()))
     val addOne = app("iadd", name, _1)(QuintIntT())
@@ -710,8 +713,12 @@ class TestQuintEx extends AnyFunSuite {
     assert(convert(Q.app("put", Q.intMap, Q._3, Q._42)(intMapT)) == expected)
   }
 
-  test("can convert nondet bindings") {
+  test("can convert nondet...oneOf") {
     assert(convert(Q.nondetBinding) == "∃n ∈ {1, 2, 3}: (n > 0)")
+  }
+
+  test("can convert nondet...generate") {
+    assert(convert(Q.nondetGenerate) == "LET n ≜ Apalache!Gen(42) IN TRUE")
   }
 
   test("can convert let binding with reference to name in scope") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -175,11 +175,12 @@ class TestQuintEx extends AnyFunSuite {
       e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", oneOfSet), QuintIntT()), nIsGreaterThan0), QuintBoolT())
     val generateSet = app("generate", _42, app("Set", _42)(QuintSetT(QuintIntT())))(QuintSetT(QuintIntT()))
     val nondetGenerateId = uid
-    val appGenSet = app("eq", e(QuintName(uid, "S"), QuintSetT(QuintIntT())), app("Set")(QuintSetT(QuintIntT())))(QuintBoolT())
+    val appGenSet =
+      app("eq", e(QuintName(uid, "S"), QuintSetT(QuintIntT())), app("Set")(QuintSetT(QuintIntT())))(QuintBoolT())
     val nondetGenerate =
       e(QuintLet(uid,
-        d(QuintDef.QuintOpDef(nondetGenerateId, "S", "nondet", generateSet), QuintOperT(Seq(), QuintSetT(QuintIntT()))), appGenSet),
-        QuintBoolT())
+              d(QuintDef.QuintOpDef(nondetGenerateId, "S", "nondet", generateSet),
+                  QuintOperT(Seq(), QuintSetT(QuintIntT()))), appGenSet), QuintBoolT())
     // Requires ID registered with type
     val selectGreaterThanZero = app("select", intList, intIsGreaterThanZero)(QuintSeqT(QuintIntT()))
     val addOne = app("iadd", name, _1)(QuintIntT())

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -173,9 +173,13 @@ class TestQuintEx extends AnyFunSuite {
     val oneOfSet = app("oneOf", intSet)(QuintIntT())
     val nondetBinding =
       e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", oneOfSet), QuintIntT()), nIsGreaterThan0), QuintBoolT())
-    val generateSet = app("generate", _42, _42)(QuintSetT(QuintIntT()))
+    val generateSet = app("generate", _42, app("Set", _42)(QuintSetT(QuintIntT())))(QuintSetT(QuintIntT()))
+    val nondetGenerateId = uid
+    val appGenSet = app("eq", e(QuintName(uid, "S"), QuintSetT(QuintIntT())), app("Set")(QuintSetT(QuintIntT())))(QuintBoolT())
     val nondetGenerate =
-      e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", generateSet), QuintIntT()), tt), QuintBoolT())
+      e(QuintLet(uid,
+        d(QuintDef.QuintOpDef(nondetGenerateId, "S", "nondet", generateSet), QuintOperT(Seq(), QuintSetT(QuintIntT()))), appGenSet),
+        QuintBoolT())
     // Requires ID registered with type
     val selectGreaterThanZero = app("select", intList, intIsGreaterThanZero)(QuintSeqT(QuintIntT()))
     val addOne = app("iadd", name, _1)(QuintIntT())
@@ -718,7 +722,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert nondet...generate") {
-    assert(convert(Q.nondetGenerate) == "LET n ≜ Apalache!Gen(42) IN TRUE")
+    assert(convert(Q.nondetGenerate) == "∃S ∈ {Apalache!Gen(42)}: (S = {})")
   }
 
   test("can convert let binding with reference to name in scope") {


### PR DESCRIPTION
This PR adds translation of Quint `generate` introduced in https://github.com/informalsystems/quint/pull/1455 into `Apalache!Gen`.

- [x] Tests added for any new code
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
