### PR TITLE
provisionally disable docker-tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,6 +166,8 @@ jobs:
           TEST_FILTER: ${{ matrix.smt-encoding == 'arrays' && 'array-encoding' || '' }}
 
   docker-tests:
+    # provisionally disable docker tests until we repair them
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`docker-tests` is failing after the migration to the org `apalache-mc`. Provisionally, disabling this workflow. Repairing is filed in #2931.