### PR TITLE
add `--timeout-smt` to `check` and `simulate`

### DIFF
--- a/.unreleased/features/timeout-smt.md
+++ b/.unreleased/features/timeout-smt.md
@@ -1,0 +1,1 @@
+Add `--timeout-smt` to limit SMT queries (#2936)

--- a/docs/src/apalache/tuning.md
+++ b/docs/src/apalache/tuning.md
@@ -22,14 +22,6 @@ The following options are supported:
 `smt.randomSeed=<int>` passes the random seed to `z3` (via `z3`'s parameters
 `sat.random_seed` and `smt.random_seed`).
 
-##  Timeouts
-
-`search.smt.timeout=<seconds>` defines the timeout to the SMT solver in seconds.
-The default value is `0`, which stands for the unbounded timeout.  For instance,
-the timeout is used in the following cases: checking if a transition is enabled,
-checking an invariant, checking for deadlocks. If the solver times out, it
-reports 'UNKNOWN', and the model checker reports a runtime error.
-
 ## Invariant mode
 
 `search.invariant.mode=(before|after)` defines the moment when the invariant is

--- a/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
+++ b/mod-infra/src/main/scala/at/forsyte/apalache/infra/passes/options.scala
@@ -162,6 +162,8 @@ object Config {
    *   maximal number of Next steps
    * @param maxError
    *   whether to stop on the first error or to produce up to a given number of counterexamples
+   * @param timeoutSmtSec
+   *   the time limit on SMT queries in seconds
    * @param noDeadLocks
    *   do not check for deadlocks
    * @param smtEncoding
@@ -182,6 +184,7 @@ object Config {
       next: Option[String] = None,
       length: Option[Int] = Some(10),
       maxError: Option[Int] = Some(1),
+      timeoutSmtSec: Option[Int] = Some(0),
       noDeadlocks: Option[Boolean] = Some(false),
       smtEncoding: Option[SMTEncoding] = Some(SMTEncoding.OOPSLA19),
       temporalProps: Option[List[String]] = None,
@@ -660,6 +663,7 @@ object OptionGroup extends LazyLogging {
       discardDisabled: Boolean,
       length: Int,
       maxError: Int,
+      timeoutSmtSec: Int,
       noDeadlocks: Boolean,
       smtEncoding: SMTEncoding,
       tuning: Map[String, String])
@@ -684,11 +688,13 @@ object OptionGroup extends LazyLogging {
         smtEncoding <- checker.smtEncoding.toTry("checker.smtEncoding")
         tuning <- checker.tuning.toTry("checker.tuning")
         maxError <- checker.maxError.toTry("checker.maxError").flatMap(validateMaxError)
+        timeoutSmtSec <- checker.timeoutSmtSec.toTry("checker.timeoutSmtSec")
       } yield Checker(
           algo = algo,
           discardDisabled = discardDisabled,
           length = length,
           maxError = maxError,
+          timeoutSmtSec = timeoutSmtSec,
           noDeadlocks = noDeadlocks,
           smtEncoding = smtEncoding,
           tuning = tuning,

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -71,9 +71,8 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
 
   var timeoutSmtSec: Option[Int] =
     opt[Option[Int]](name = "timeout-smt",
-      description =
-        "limit the duration of a single SMT check query with `n` seconds, default: 0 (unlimited)",
-      default = None)
+        description = "limit the duration of a single SMT check query with `n` seconds, default: 0 (unlimited)",
+        default = None)
 
   override def toConfig(): Try[Config.ApalacheConfig] = {
     val loadedTuningOptions = tuningOptionsFile.map(f => loadProperties(f)).getOrElse(Map())

--- a/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
+++ b/mod-tool/src/main/scala/at/forsyte/apalache/tla/tooling/opt/CheckCmd.scala
@@ -69,6 +69,12 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
     opt[Boolean](name = "output-traces", description = "save an example trace for each symbolic run, default: false",
         default = false)
 
+  var timeoutSmtSec: Option[Int] =
+    opt[Option[Int]](name = "timeout-smt",
+      description =
+        "limit the duration of a single SMT check query with `n` seconds, default: 0 (unlimited)",
+      default = None)
+
   override def toConfig(): Try[Config.ApalacheConfig] = {
     val loadedTuningOptions = tuningOptionsFile.map(f => loadProperties(f)).getOrElse(Map())
     val combinedTuningOptions = overrideProperties(loadedTuningOptions, tuningOptions.getOrElse("")) ++ Map(
@@ -83,6 +89,7 @@ class CheckCmd(name: String = "check", description: String = "Check a TLA+ speci
               discardDisabled = discardDisabled,
               noDeadlocks = noDeadlocks,
               maxError = maxError,
+              timeoutSmtSec = timeoutSmtSec,
               view = view,
           ),
           typechecker = cfg.typechecker.copy(

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3904,6 +3904,7 @@ checker {
     smt-encoding {
         type=oopsla-19
     }
+    timeout-smt-sec=0
     tuning {
         "search.outputTraces"="false"
     }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -1752,6 +1752,18 @@ The outcome is: NoError
 EXITCODE: OK
 ```
 
+### simulate Paxos.tla with timeout succeeds
+
+While we cannot rely on an actual timeout happening or not, we can make sure that the option is properly parsed. 
+
+```sh
+$ apalache-mc simulate --timeout-smt=1 --length=10 --inv=Inv Paxos.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+EXITCODE: OK
+```
+
 ### simulate y2k with --output-traces succeeds
 
 ```sh

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
@@ -23,6 +23,8 @@ object Checker {
         Obj("checking_result" -> "Error", "counterexamples" -> counterexamples, "nerrors" -> nerrors)
       case Deadlock(counterexample) =>
         Obj("checking_result" -> "Deadlock", "counterexamples" -> counterexample.toList)
+      case SmtTimeout(nTimeouts) =>
+        Obj("checking_result" -> "SmtTimeout", "ntimeouts" -> nTimeouts)
       case other =>
         Obj("checking_result" -> other.toString())
     }
@@ -57,6 +59,19 @@ object Checker {
   case class ExecutionsTooShort() extends CheckerResult {
     override def toString: String = "ExecutionsTooShort"
 
+    override val isOk: Boolean = true
+  }
+
+  /**
+   * The SMT solver reported a timeout. It should still be possible to check other verification conditions.
+   * @param nTimeouts the number of timeouts, normally, just 1.
+   */
+  case class SmtTimeout(nTimeouts: Int) extends CheckerResult {
+    override def toString: String = "SmtTimeout"
+
+    /**
+     * Whether this result shall be reported as success (`true`) or error (`false`).
+     */
     override val isOk: Boolean = true
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/Checker.scala
@@ -64,7 +64,8 @@ object Checker {
 
   /**
    * The SMT solver reported a timeout. It should still be possible to check other verification conditions.
-   * @param nTimeouts the number of timeouts, normally, just 1.
+   * @param nTimeouts
+   *   the number of timeouts, normally, just 1.
    */
   case class SmtTimeout(nTimeouts: Int) extends CheckerResult {
     override def toString: String = "SmtTimeout"

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/passes/BoundedCheckerPassImpl.scala
@@ -70,6 +70,7 @@ class BoundedCheckerPassImpl @Inject() (
     params.discardDisabled = options.checker.discardDisabled
     params.checkForDeadlocks = !options.checker.noDeadlocks
     params.nMaxErrors = options.checker.maxError
+    params.timeoutSmtSec = options.checker.timeoutSmtSec
     params.smtEncoding = smtEncoding
 
     val smtProfile = options.common.smtprof

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/search/ModelCheckerParams.scala
@@ -69,6 +69,11 @@ class ModelCheckerParams(
   var nMaxErrors: Int = 1
 
   /**
+   * The limit on a single SMT query. The default value is 0 (unlimited).
+   */
+  var timeoutSmtSec: Int = 0
+
+  /**
    * A timeout upon which a transition is split in its own group. This is the minimal timeout. The actual timeout is
    * updated at every step using `search.split.timeout.factor`. In our experiments, small timeouts lead to explosion of
    * the search tree.
@@ -95,9 +100,6 @@ class ModelCheckerParams(
    * node into two.
    */
   def idleTimeoutMs: Long = idleTimeoutSec * 1000
-
-  val smtTimeoutSec: Int =
-    tuningOptions.getOrElse("search.smt.timeout", "0").toInt
 
   /**
    * The SMT encoding to be used.


### PR DESCRIPTION
In our experiments, it sometimes happens that `apalache-mc simulate` gets stuck in a randomly selected schedule, without progressing for many hours. Since we would like to get quicker feedback with `simulate`, this PR add the CLI option `--timeout-smt` that limits the time spent on a single SMT query. Also, we are removing the old tuning option `search.smt.timeout`, which is hard to discover.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
