### PR TITLE
Rewrite for set membership of the powerset of a record where the record has infinite co-domains.

### DIFF
--- a/.unreleased/features/rewrite.md
+++ b/.unreleased/features/rewrite.md
@@ -1,0 +1,1 @@
+Handle expressions such as  S \in SUBSET [ a : Int ]  by rewriting the expression into  \A r \in S: DOMAIN r = {"a"} /\ r.a \in Int


### PR DESCRIPTION
### Simplified real-world scenario:
```tla
EXTENDS Integers

VARIABLE
  \* @type: Set({ p: (Int) });
  v

TypeOK ==
  v \in SUBSET [ p: Int ]

Init ==
  v = { [p |-> 42] }

Next ==
  UNCHANGED v
```

### Apalache Error:
```sh
$ apalache-mc check --inv=TypeOK APARecSub.tla
[...]
Input error (see the manual): Found a set map over an infinite set of CellTFrom(Int). Not supported.
```

### Rewrite:
```tla
S \in SUBSET [a : T] ~~> \A r \in S: DOMAIN r = { "a" } /\ r.a \in T
```

Related commits, issues, PRs:
* 625a1645e75a910d43759c36ad8a06291ebc55b3
* 785e26925a45b077e14cf79f31f834e0c0919639

* https://github.com/apalache-mc/apalache/issues/723
* https://github.com/apalache-mc/apalache/issues/1627
* https://github.com/apalache-mc/apalache/issues/2762

* https://github.com/apalache-mc/apalache/pull/1453
* https://github.com/apalache-mc/apalache/pull/1629


### PR hygiene
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
