### PR TITLE
enable docker tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,8 +166,6 @@ jobs:
           TEST_FILTER: ${{ matrix.smt-encoding == 'arrays' && 'array-encoding' || '' }}
 
   docker-tests:
-    # provisionally disable docker tests until we repair them
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
closes #2931. Since the docker container is now properly built #2932, the docker tests should be working again