### PR TITLE
ExprOptimizer: Rewrite `S \in SUBSET T` when it occurs in subexpressions

### DIFF
--- a/.unreleased/features/rewrite.md
+++ b/.unreleased/features/rewrite.md
@@ -1,0 +1,1 @@
+Handle expressions such as  S \in SUBSET T  in ExprOptimizer by rewriting the expression into  \A r \in S: r \in T

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestExprOptimizer.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestExprOptimizer.scala
@@ -184,6 +184,19 @@ class TestExprOptimizer extends AnyFunSuite with BeforeAndAfterEach {
     assert(expected == output)
   }
 
+  test("""S \in SUBSET T ~~> \A s \in S: s \in T""") {
+    val T = name("T").as(intSetT)
+    val S = name("S").as(intSetT)
+    val powSetT = powSet(T).as(intSetT)
+    val input = in(S, powSetT).as(boolT)
+    val output = optimizer.apply(input)
+
+    val s = name("t_1").as(intT)
+    val expected = forall(s, S, in(s, T).as(boolT)).as(boolT)
+
+    assert(expected == output)
+  }
+
   // optimizations for set cardinalities
 
   test("""Cardinality(S) = 0 becomes S = {}""") {


### PR DESCRIPTION
```tla
----- MODULE ljasf -----
EXTENDS Integers

VARIABLE
    \* @type: { v: Set( { p: Set( { v: Set(Int) } ) } ) };
    m

TypeOK ==
        m \in [ v : SUBSET [ p : SUBSET [ v: SUBSET {1,2,3,4,5}] ] ]

Init ==
    m = [ v |-> {[p |-> {[v |-> {1}]} ]} ]

Next ==
    UNCHANGED m
====
```

```
input:
m["v"] ∈ SUBSET ({["p" ↦ t_5$1] : t_5$1 ∈ SUBSET ({["v" ↦ t_4$1] : t_4$1 ∈ SUBSET {1, 2, 3, 4, 5}})})

old output:
∀t_a ∈ m["v"]: ((DOMAIN t_a = {"p"}) ∧ (∀t_b ∈ t_a["p"]: ((DOMAIN t_b = {"v"}) ∧ t_b["v"] ∈ SUBSET {1, 2, 3, 4, 5})))

new output:
∀t_a ∈ m["v"]: ((DOMAIN t_a = {"p"}) ∧ (∀t_b ∈ t_a["p"]: ((DOMAIN t_b = {"v"}) ∧ (∀t_c ∈ t_b["v"]: t_c ∈ {1, 2, 3, 4, 5}))))
```

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] ~Documentation added for any new functionality~ (nothing to document)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality
