### PR TITLE
Update upickle to 4.0.0 and remove unecessary customizations

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,8 +34,8 @@ object Dependencies {
     val slf4j = "org.slf4j" % "slf4j-api" % "2.0.16"
     val shapeless = "com.chuusai" %% "shapeless" % "2.3.12"
     val tla2tools = "org.lamport" % "tla2tools" % "1.7.0-SNAPSHOT"
-    val ujson = "com.lihaoyi" %% "ujson" % "3.2.0"
-    val upickle = "com.lihaoyi" %% "upickle" % "3.2.0"
+    val ujson = "com.lihaoyi" %% "ujson" % "4.0.0"
+    val upickle = "com.lihaoyi" %% "upickle" % "4.0.0"
     val z3 = "tools.aqua" % "z3-turnkey" % "4.13.0"
     val zio = "dev.zio" %% "zio" % zioVersion
     // Keep up to sync with version in plugins.sbt

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintIR.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintIR.scala
@@ -49,7 +49,8 @@ class TestQuintIR extends AnyFunSuite {
 
   test("Simple QuintDef works correctly") {
     val quintDef = QuintOpDef(1, "myDef", "val", QuintBool(2, true))
-    assert(QuintDeserializer.write[QuintDef](quintDef) == """{"kind":"def","id":1,"name":"myDef","qualifier":"val","expr":{"kind":"bool","id":2,"value":true}}""")
+    assert(QuintDeserializer.write[QuintDef](
+        quintDef) == """{"kind":"def","id":1,"name":"myDef","qualifier":"val","expr":{"kind":"bool","id":2,"value":true}}""")
   }
 
   test("QuintTypeDef works correctly") {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintIR.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintIR.scala
@@ -1,6 +1,6 @@
 package at.forsyte.apalache.io.quint
 
-import at.forsyte.apalache.io.quint.QuintDef.QuintAssume
+import at.forsyte.apalache.io.quint.QuintDef.{QuintAssume, QuintOpDef, QuintTypeDef}
 import at.forsyte.apalache.io.quint.QuintEx.QuintBool
 import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
@@ -45,6 +45,19 @@ class TestQuintIR extends AnyFunSuite {
 
     val unnamedAssume = QuintAssume(1, "_", QuintBool(2, true))
     assert(unnamedAssume.isUnnamed)
+  }
+
+  test("Simple QuintDef works correctly") {
+    val quintDef = QuintOpDef(1, "myDef", "val", QuintBool(2, true))
+    assert(QuintDeserializer.write[QuintDef](quintDef) == """{"kind":"def","id":1,"name":"myDef","qualifier":"val","expr":{"kind":"bool","id":2,"value":true}}""")
+  }
+
+  test("QuintTypeDef works correctly") {
+    val typeDef = QuintTypeDef(1, "myType", None)
+    val typeDefJson = """{"kind":"typedef","id":1,"name":"myType"}"""
+
+    assert(QuintDeserializer.write[QuintTypeDef](typeDef) == typeDefJson)
+    assert(QuintDeserializer.read[QuintTypeDef](typeDefJson) == typeDef)
   }
 
   // tictactoe.json is located in tla-io/src/test/resources/tictactoe.json


### PR DESCRIPTION
Hello :octocat: 

This is a replacement for https://github.com/apalache-mc/apalache/pull/2905

I've updated `upickle` and `ujson` all the way to the most recent version (`4.0.0`), as that includes features for things we had to work around before. This way, I was able to remove all of the customized `rw` values, as `macroRW` works for everything now (with the proper config updates).

I've also added a couple of tests that helped me debug things, but no behavior was changed.

I checked that this version is compatible with all Quint's integration tests.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [-] Documentation added for any new functionality
- [-] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
