### PR TITLE
produce true on distinct for less than 2 elements

### DIFF
--- a/.unreleased/bug-fixes/distinct-on-singleton.md
+++ b/.unreleased/bug-fixes/distinct-on-singleton.md
@@ -1,1 +1,1 @@
-Do not produce `(distinct ...)` for singletons (see #3005)
+Do not produce `(distinct ...)` for singletons, see #3005

--- a/.unreleased/bug-fixes/distinct-on-singleton.md
+++ b/.unreleased/bug-fixes/distinct-on-singleton.md
@@ -1,0 +1,1 @@
+Do not produce `(distinct ...)` for singletons (see #3005)

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/smt/Z3SolverContext.scala
@@ -765,12 +765,17 @@ class Z3SolverContext(val config: SolverConfig) extends SolverContext with LazyL
         (z3context.mkNot(eq.asInstanceOf[BoolExpr]).asInstanceOf[ExprSort], 1 + n)
 
       case OperEx(ApalacheInternalOper.distinct, args @ _*) =>
-        val (es, ns) = (args.map(toExpr)).unzip
-        val distinct = z3context.mkDistinct(es: _*)
-        (distinct.asInstanceOf[ExprSort],
-            ns.foldLeft(1L) {
-              _ + _
-            })
+        if (args.length < 2) {
+          // Produce true for a singleton set or an empty set. Otherwise, we cannot replay the SMT log in CVC5.
+          (z3context.mkTrue().asInstanceOf[ExprSort], 1)
+        } else {
+          val (es, ns) = (args.map(toExpr)).unzip
+          val distinct = z3context.mkDistinct(es: _*)
+          (distinct.asInstanceOf[ExprSort],
+              ns.foldLeft(1L) {
+                _ + _
+              })
+        }
 
       case OperEx(TlaBoolOper.and, args @ _*) =>
         val (es, ns) = (args.map(toExpr)).unzip


### PR DESCRIPTION
Closes #2964. Simply translate `distinst` into `true`, when we have less than two subexpressions. It's only relevant for replaying SMT logs in CVC5, but it was sufficiently annoying for me to fix it.

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
