### PR TITLE
Downgrade Z3 to 4.12.6

### DIFF
--- a/.unreleased/breaking-changes/downgrade-z3.md
+++ b/.unreleased/breaking-changes/downgrade-z3.md
@@ -1,0 +1,1 @@
+Downgrade z3 to 4.12.6, due to instability of 4.13.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     val tla2tools = "org.lamport" % "tla2tools" % "1.7.0-SNAPSHOT"
     val ujson = "com.lihaoyi" %% "ujson" % "4.0.2"
     val upickle = "com.lihaoyi" %% "upickle" % "4.0.2"
-    val z3 = "tools.aqua" % "z3-turnkey" % "4.13.0"
+    val z3 = "tools.aqua" % "z3-turnkey" % "4.12.6"
     val zio = "dev.zio" %% "zio" % zioVersion
     // Keep up to sync with version in plugins.sbt
     val zioGrpcCodgen = "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0-test3" % "provided"


### PR DESCRIPTION
Since I've hit assertion failures and even cores dumped with 4.13.0, downgrading z3 to 4.12.6. This is a potentially breaking (unbreaking) change, so we will cut a separate minor release for this.

- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality
