### PR TITLE
Replace some left-over Zulip links with Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Related reports and publications can be found at the
 [releases page]: https://github.com/apalache-mc/apalache/releases
 [master]: https://github.com/apalache-mc/apalache/tree/master
 [main branch]: https://github.com/apalache-mc/apalache/tree/main
-[apalache zulip stream]: https://informal-systems.zulipchat.com/#narrow/stream/265309-apalache
 [tendermint specs]: https://github.com/tendermint/tendermint/tree/master/spec/light-client/accountability
 [tendermint blockchain]: https://github.com/tendermint
 [standard repository of tla+ examples]: https://github.com/tlaplus/Examples

--- a/docs/src/adr/006rfc-unit-testing.md
+++ b/docs/src/adr/006rfc-unit-testing.md
@@ -621,14 +621,14 @@ By having all test options specified directly in tests, we reach two goals:
 
 Let us know:
 
- - At [Apalache Zulip stream][],
+ - At [Apalache Discourse][],
 
  - On [ApalacheTLA Twitter][],
 
  - email: igor at informal.systems.
 
 
-[Apalache Zulip stream]: https://informal-systems.zulipchat.com/#narrow/stream/265309-apalache
+[Apalache Discourse]: https://apalache.discourse.group/
 [ApalacheTLA Twitter]: https://twitter.com/ApalacheTLA
 [Unit testing]: https://en.wikipedia.org/wiki/Unit_testing
 [Property-based testing]: https://en.wikipedia.org/wiki/QuickCheck

--- a/docs/src/tutorials/entry-tutorial.md
+++ b/docs/src/tutorials/entry-tutorial.md
@@ -1175,7 +1175,7 @@ did not discuss non-determinism, as our specification is entirely
 deterministic. We will demonstrate advanced features in future tutorials.
 
 If you are experiencing a problem with Apalache, feel free to [open an issue]
-or drop us a message on [Zulip chat].
+or drop us a message on [Discourse].
 
 
 [HOWTO on writing type annotations]: ../HOWTOs/howto-write-type-annotations.md
@@ -1205,5 +1205,5 @@ or drop us a message on [Zulip chat].
 [Specifying Systems]: http://lamport.azurewebsites.net/tla/book.html?back-link=learning.html
 [Test-driven development]: https://en.wikipedia.org/wiki/Test-driven_development
 [TLC]: https://github.com/tlaplus/tlaplus/
-[Zulip chat]: https://informal-systems.zulipchat.com/login/#narrow/stream/265309-apalache
+[Discourse]: https://apalache.discourse.group/
 [ZIP archive]: https://download-directory.github.io/?url=https://github.com/informalsystems/apalache/tree/main/test/tla/bin-search

--- a/docs/src/tutorials/pluscal-tutorial.md
+++ b/docs/src/tutorials/pluscal-tutorial.md
@@ -256,7 +256,7 @@ In this tutorial, we have shown how to:
    `N=4`).
 
 If you are experiencing a problem with Apalache, feel free to [open an issue]
-or drop us a message on [Zulip chat].
+or drop us a message on [Discourse].
 
 ## Further reading
 
@@ -284,6 +284,6 @@ or drop us a message on [Zulip chat].
 [Specifying Systems]: http://lamport.azurewebsites.net/tla/book.html?back-link=learning.html
 [TLC]: https://github.com/tlaplus/tlaplus/
 [TLAPS]: https://tla.msr-inria.inria.fr/tlaps/content/Home.html
-[Zulip chat]: https://informal-systems.zulipchat.com/login/#narrow/stream/265309-apalache
+[Discourse]: https://apalache.discourse.group/
 [Bakery algorithm]: https://en.wikipedia.org/wiki/Lamport%27s_bakery_algorithm
 [ZIP archive]: https://download-directory.github.io/?url=https://github.com/informalsystems/apalache/tree/main/test/tla/bakery-pluscal

--- a/docs/src/tutorials/snowcat-tutorial.md
+++ b/docs/src/tutorials/snowcat-tutorial.md
@@ -292,7 +292,7 @@ type checker. To learn about type aliases, see [HOWTO on writing type
 annotations][].
 
 If you are experiencing a problem with Snowcat, feel free to [open an issue][]
-or drop us a message on [Zulip chat][].
+or drop us a message on [Discourse][].
 
 
 [ADR002]: ../adr/002adr-types.md
@@ -312,5 +312,5 @@ or drop us a message on [Zulip chat][].
 [CarTalkPuzzleTyped.tla]: https://github.com/informalsystems/apalache/blob/main/test/tla/CarTalkPuzzleTyped.tla
 [QueensTyped.tla]: https://github.com/informalsystems/apalache/blob/main/test/tla/QueensTyped.tla
 [open an issue]: https://github.com/informalsystems/apalache/issues
-[Zulip chat]: https://informal-systems.zulipchat.com/login/#narrow/stream/265309-apalache
+[Discourse]: https://apalache.discourse.group/
 [Idiom 15]: ../idiomatic/003record-sets.md


### PR DESCRIPTION
Replace some left-over links to Zulip with Discourse