### PR TITLE
Quint -> TLA+ transpilation fixes

### DIFF
--- a/.unreleased/bug-fixes/quint-to-tla-transpilation.md
+++ b/.unreleased/bug-fixes/quint-to-tla-transpilation.md
@@ -1,0 +1,1 @@
+Fixed a few problems on parsing Quint and pretty printing TLA, see #3041

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -534,14 +534,14 @@ class PrettyWriter(
    */
   def extractDecls(exprs: Seq[TlaEx]): (List[Doc], Seq[TlaEx]) = {
     val decls = exprs.collect {
-      case LetInEx(body, d @ TlaOperDecl("LAMBDA", _, _)) => Nil
-      case LetInEx(_, decls @ _*) => decls
-      case _                      => Nil
+      case LetInEx(_, TlaOperDecl("LAMBDA", _, _)) => Nil
+      case LetInEx(_, decls @ _*)                  => decls
+      case _                                       => Nil
     }
     val newArgs = exprs.collect {
-      case expr @ LetInEx(body, d @ TlaOperDecl("LAMBDA", _, _)) => expr
-      case LetInEx(body, _) => body
-      case expr             => expr
+      case expr @ LetInEx(_, TlaOperDecl("LAMBDA", _, _)) => expr
+      case LetInEx(body, _)                               => body
+      case expr                                           => expr
     }
 
     (decls.flatten.map(d => group("LET" <> space <> declToDoc(d) <> line <> "IN")).toList, newArgs)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -474,6 +474,8 @@ class PrettyWriter(
         val doc =
           if (args.isEmpty) {
             text(parseableName(name))
+          } else if (decls.isEmpty) {
+            group(parseableName(name) <> parens(commaSeparated))
           } else {
             group(ssep(decls, line) <> line <> parseableName(name) <> parens(commaSeparated))
           }
@@ -499,6 +501,8 @@ class PrettyWriter(
         val doc =
           if (args.isEmpty) {
             text(unqualifiedName)
+          } else if (decls.isEmpty) {
+            group(unqualifiedName <> parens(commaSeparated))
           } else {
             group(ssep(decls, line) <> line <> unqualifiedName <> parens(commaSeparated))
           }
@@ -530,10 +534,12 @@ class PrettyWriter(
    */
   def extractDecls(exprs: Seq[TlaEx]): (List[Doc], Seq[TlaEx]) = {
     val decls = exprs.collect {
+      case LetInEx(body, d @ TlaOperDecl("LAMBDA", _, _)) => Nil
       case LetInEx(_, decls @ _*) => decls
       case _                      => Nil
     }
     val newArgs = exprs.collect {
+      case expr @ LetInEx(body, d @ TlaOperDecl("LAMBDA", _, _)) => expr
       case LetInEx(body, _) => body
       case expr             => expr
     }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -297,14 +297,6 @@ class PrettyWriter(
             text("{") <> nest(line <> binding <> ":" <> nest(line <> filter)) <> line <> text("}")
         ) ///
 
-      // a function of multiple arguments that are packed into a tuple: don't print the angular brackets <<...>>
-      case OperEx(op @ TlaFunOper.app, funEx, OperEx(TlaFunOper.tuple, args @ _*)) =>
-        val argDocs = args.map(exToDoc(op.precedence, _, nameResolver))
-        val commaSeparatedArgs = folddoc(argDocs.toList, _ <> text(",") <@> _)
-        group(
-            exToDoc(TlaFunOper.app.precedence, funEx, nameResolver) <> brackets(commaSeparatedArgs)
-        ) ///
-
       // a function of a single argument
       case OperEx(TlaFunOper.app, funEx, argEx) =>
         group(

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -446,7 +446,7 @@ class Quint(quintOutput: QuintOutput) {
             case ValEx(TlaStr("_")) =>
               // We have a default case, which is always paired with an eliminator that
               // can be applied to the unit value (an empty record).
-              (cs, Some(tla.appOp(defaultElim, tla.rowRec(None))))
+              (cs, Some(tla.appOp(defaultElim, tla.emptySet(IntT1))))
             case _ =>
               // All cases have match expressions
               (allCases, None)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -573,7 +573,7 @@ class Quint(quintOutput: QuintOutput) {
         case "Tup" =>
           if (quintArgs.isEmpty) {
             // Translate empty tuples to values of type UNIT
-            (_) => Reader((_) => tla.const("U", ConstT1(("UNIT"))))
+            (_) => Reader((_) => tla.rowRec(None, "tag" -> tla.str("UNIT")))
           } else {
             variadicApp(args => tla.tuple(args: _*))
           }

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
@@ -96,10 +96,10 @@ private class QuintTypeConverter extends LazyLogging {
     case QuintSeqT(elem)       => SeqT1(convert(elem))
     case QuintFunT(arg, res)   => FunT1(convert(arg), convert(res))
     case QuintOperT(args, res) => OperT1(args.map(convert), convert(res))
+    // Use the Unit type for empty tuples, since they are the unit type in Quint
+    // The unit type is a record like [ "tag" |-> "UNIT" ] so it can be compared to other constructed types.
+    // This is relevant when we produce a TLA+ file to be used with TLC.
     case QuintTupleT(Row.Nil() | Row.Cell(Seq(), _)) =>
-      // Use the Unit type for empty tuples, since they are the unit type in Quint
-      // The unit type is a record like [ "tag" |-> "UNIT" ] so it can be compared to other constructed types.
-      // This is relevant when we produce a TLA+ file to be used with TLC.
       RecRowT1(RowT1("tag" -> StrT1))
     case QuintTupleT(row)  => rowToTupleT1(row)
     case QuintRecordT(row) => RecRowT1(rowToRowT1(row))

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/QuintTypeConverter.scala
@@ -97,7 +97,10 @@ private class QuintTypeConverter extends LazyLogging {
     case QuintFunT(arg, res)   => FunT1(convert(arg), convert(res))
     case QuintOperT(args, res) => OperT1(args.map(convert), convert(res))
     case QuintTupleT(Row.Nil() | Row.Cell(Seq(), _)) =>
-      ConstT1("UNIT") // Use the Unit type for empty tuples, since they are the unit type in Quint
+      // Use the Unit type for empty tuples, since they are the unit type in Quint
+      // The unit type is a record like [ "tag" |-> "UNIT" ] so it can be compared to other constructed types.
+      // This is relevant when we produce a TLA+ file to be used with TLC.
+      RecRowT1(RowT1("tag" -> StrT1))
     case QuintTupleT(row)  => rowToTupleT1(row)
     case QuintRecordT(row) => RecRowT1(rowToRowT1(row))
     case QuintSumT(row)    => VariantT1(rowToRowT1(row))

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -844,6 +844,24 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     assert(expected == stringWriter.toString)
   }
 
+  test("operator application with LET-IN as argument") {
+    val writer = new PrettyWriter(printWriter, layout40)
+    val decl1 =
+      TlaOperDecl("A", List(OperParam("param1"), OperParam("param2")), plus(name("param1"), name("param2")))
+    val letInEx = letIn(appDecl(decl1, int(1), int(2)), decl1)
+    // Foo(LET A(param1, param2) == param1 + param2 IN A(1, 2))
+    val expr = OperEx(TlaOper.apply, NameEx("Foo"), letInEx)
+
+    writer.write(expr)
+    printWriter.flush()
+    // LET declaration needs to be printed before the application
+    val expected =
+      """LET A(param1, param2) == param1 + param2
+        |IN
+        |Foo((A(1, 2)))""".stripMargin
+    assert(expected == stringWriter.toString)
+  }
+
   test("a LAMBDA as LET-IN") {
     val writer = new PrettyWriter(printWriter, layout40)
     val aDecl = TlaOperDecl("LAMBDA", List(OperParam("x")), NameEx("x"))

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -989,7 +989,7 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     writer.write(fDecl)
     printWriter.flush()
     val expected =
-      """f[x \in S, y \in S] == f[y, x]
+      """f[x \in S, y \in S] == f[<<y, x>>]
         |
         |""".stripMargin
     assert(expected == stringWriter.toString)

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -625,7 +625,7 @@ class TestQuintEx extends AnyFunSuite {
   }
 
   test("can convert builtin empty Tup operator application to uninterpreted value") {
-    assert(convert(Q.app("Tup")(QuintTupleT.ofTypes())) == "\"U_OF_UNIT\"")
+    assert(convert(Q.app("Tup")(QuintTupleT.ofTypes())) == "[\"tag\" ↦ \"UNIT\"]")
   }
 
   /// SUM TYPES
@@ -651,7 +651,7 @@ class TestQuintEx extends AnyFunSuite {
     val expected =
       """|CASE (Variants!VariantTag(Variants!Variant("F1", 42)) = "F1") → LET __QUINT_LAMBDA0(x) ≜ 1 IN __QUINT_LAMBDA0(Variants!VariantGetUnsafe("F1", Variants!Variant("F1", 42)))
          |☐ (Variants!VariantTag(Variants!Variant("F1", 42)) = "F2") → LET __QUINT_LAMBDA1(y) ≜ 2 IN __QUINT_LAMBDA1(Variants!VariantGetUnsafe("F2", Variants!Variant("F1", 42)))
-         |☐ OTHER → LET __QUINT_LAMBDA2(_) ≜ 2 IN __QUINT_LAMBDA2([])""".stripMargin
+         |☐ OTHER → LET __QUINT_LAMBDA2(_) ≜ 2 IN __QUINT_LAMBDA2({})""".stripMargin
         .replace('\n', ' ')
     assert(convert(quintMatch) == expected)
   }

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
@@ -5,7 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import at.forsyte.apalache.io.quint.QuintType._
 import at.forsyte.apalache.tla.lir.{
-  ConstT1, FunT1, IntT1, RecRowT1, RowT1, SparseTupT1, StrT1, TlaType1, TupT1, VarT1, VariantT1,
+  FunT1, IntT1, RecRowT1, RowT1, SparseTupT1, StrT1, TlaType1, TupT1, VarT1, VariantT1,
 }
 
 /**

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintTypes.scala
@@ -35,7 +35,7 @@ class TestQuintTypes extends AnyFunSuite {
 
   test("empty Quint tuple types are converted to the UNIT uninterpreted type") {
     val tuple = QuintTupleT(Row.Nil())
-    assert(translate(tuple) == ConstT1("UNIT"))
+    assert(translate(tuple) == RecRowT1(RowT1("tag" -> StrT1)))
   }
 
   test("Polymorphic Quint tuples types are converted to sparse tuples") {


### PR DESCRIPTION
Hello :octocat: 

I was running into some issues when using Apalache to transpile Quint into TLA+. There were even parsing errors with invalid parenthesis. After much debugging, I got to fix all of the ones I know of, except for the assignments in init (which are not a big deal because there's only one init per spec so it's always easy to manually fix those).

Here are the issues:

1. Whenever we had a default eliminator on a match, we would produce something like `QUINT_LAMBDA1([])`, but `[]` is not a valid TLA+ expression. I've replaced it with `{}`.
2. When accessing a map (function) with lists as domains, we need to do something like `map[<<1, 2>>]` but the pretty printer was removing the tuple wrapper on this and producing `map[1, 2]` instead which is not right.
  - I don't know why this existed. On the test, seems like it could have something to do with recursive operators, which as I understand should have been removed. It was also introduced in a recursive-operator related PR: https://github.com/apalache-mc/apalache/pull/312/files#diff-9f17d2b8582a6882dd7eb194ab597fa265a8f5423e02b724b767af7a3c444a01
3. For Quint's unit type, we were producing "U_OF_UNIT" and this was causing a TLC-specific error: TLC tried to compare some value like `[ "tag" |-> "Some", value |-> 1 ]` with `"U_OF_UNIT"` for its fingerprint generation and it failed at comparing. Replacing `"U_OF_UNIT"` with `[ "tag" |-> "UNIT" ]` fixed this problem, so that's what I did.
4. Lastly, the most complicated one: applying operators to LET-IN arguments doesn't work on TLC, and the Apalache representation transforms a lot of things into this format. I didn't want to touch anything that could affect Apalache's internals, so I only changed how this things get printed. Something that has this structure on Apalache IR:
```tla
Foo(LET A(param1, param2) == param1 + param2 IN A(1, 2))
```

will be printed as:
```tla
LET A(param1, param2) == param1 + param2 IN Foo(A(1, 2))
```

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
