### PR TITLE
protect against SANY race conditions on the filesystem

### DIFF
--- a/.unreleased/bug-fixes/sany-tmpdir.md
+++ b/.unreleased/bug-fixes/sany-tmpdir.md
@@ -1,0 +1,1 @@
+Add extra protection against the SANY race conditions on the filesystem, see #3046

--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -39,7 +39,11 @@ then
 fi
 
 # Avoid SANY concurrency issues: https://github.com/tlaplus/tlaplus/issues/688
-TD=`mktemp -d "$TMPDIR"/SANYXXXXXXXXXX`
+if [ -z "$TMPDIR" ]; then
+    TMPDIR="$(pwd)/tmp"
+    mkdir -p "$TMPDIR"
+fi
+TD=`mktemp -d -p $TMPDIR -t SANYXXXXXXXXXX`
 JVM_ARGS="${JVM_ARGS} -Djava.io.tmpdir=$TD"
 
 # Check whether the CLI args contains the debug flag

--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -39,7 +39,7 @@ then
 fi
 
 # Avoid SANY concurrency issues: https://github.com/tlaplus/tlaplus/issues/688
-if [ -z "$TMPDIR" ]; then
+if [ -z "${TMPDIR:-}" ]; then
     TMPDIR="$(pwd)/tmp"
     mkdir -p "$TMPDIR"
 fi

--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -43,8 +43,7 @@ if [ -z "$TMPDIR" ]; then
     TMPDIR="$(pwd)/tmp"
     mkdir -p "$TMPDIR"
 fi
-TD=`mktemp -d -p $TMPDIR -t SANYXXXXXXXXXX`
-JVM_ARGS="${JVM_ARGS} -Djava.io.tmpdir=$TD"
+JAVA_IO_TMPDIR=`mktemp -d -p $TMPDIR -t SANYXXXXXXXXXX`
 
 # Check whether the CLI args contains the debug flag
 if [[ "$*" =~ '--debug' ]]
@@ -52,10 +51,11 @@ then
     echo "# Tool home: $DIR"
     echo "# Package:   $APALACHE_JAR"
     echo "# JVM args: $JVM_ARGS"
+    echo "# -Djava.io.tmpdir: $JAVA_IO_TMPDIR"
     echo "#"
 fi
 
 # Run with `exec` to replace the PID, rather than running in a subshell.
 # This saves one process, and ensures signals are sent to the replacement process
 # C.f. https://github.com/sbt/sbt-native-packager/blob/e72f2f45b8cab5881add1cd62743bfc69c2b9b4d/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template#L141-L142
-exec java $JVM_ARGS -jar "$APALACHE_JAR" "$@"
+exec java $JVM_ARGS -Djava.io.tmpdir=$JAVA_IO_TMPDIR -jar "$APALACHE_JAR" "$@"

--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -43,7 +43,7 @@ if [ -z "${TMPDIR:-}" ]; then
     TMPDIR="$(pwd)/tmp"
     mkdir -p "$TMPDIR"
 fi
-JAVA_IO_TMPDIR=`mktemp -d -p $TMPDIR -t SANYXXXXXXXXXX`
+JAVA_IO_TMPDIR=`mktemp -d -t SANYXXXXXXXXXX`
 
 # Check whether the CLI args contains the debug flag
 if [[ "$*" =~ '--debug' ]]

--- a/src/universal/bin/apalache-mc
+++ b/src/universal/bin/apalache-mc
@@ -38,6 +38,10 @@ then
     JVM_ARGS="${JVM_ARGS} -Xmx4096m"
 fi
 
+# Avoid SANY concurrency issues: https://github.com/tlaplus/tlaplus/issues/688
+TD=`mktemp -d "$TMPDIR"/SANYXXXXXXXXXX`
+JVM_ARGS="${JVM_ARGS} -Djava.io.tmpdir=$TD"
+
 # Check whether the CLI args contains the debug flag
 if [[ "$*" =~ '--debug' ]]
 then


### PR DESCRIPTION
Although rare, it may still happen that multiple CLI instances of Apalache hit concurrency issues that is filed in https://github.com/tlaplus/tlaplus/issues/688 (`apalache-mc server` has a separate mutex for that):

```
$ cat t.tla
------------------- MODULE t --------------------                               
EXTENDS Integers
VARIABLE
    \* @type: Int;
    x
Init == x = 0
Next == x' = x + 1
=================================================
$ seq 1 100 | parallel ~/devl/apalache/bin/apalache-mc parse --out-dir=c/{} t.tla
...
Encountered an exception while attempt to validate /var/folders/93/s11lf4f16c77bpq91r90njbm0000gn/T/Naturals.tla - /var/folders/93/s11lf4f16c77bpq91r90njbm0000gn/T/Naturals.tla (No such file or directory)
```

This is a simple fix that was already discussed in https://github.com/tlaplus/tlaplus/issues/688. We simply set `java.io.tmpdir` to a specific directory.

Actually, it seems like we have fixed it in #1959, but the above test shows otherwise.

- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
