### PR TITLE
fixing sbt in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      # see: https://github.com/actions/runner-images/issues/10788
+      - uses: sbt/setup-sbt@v1
       - name: Check scaladoc
         run: sbt unidoc
 
@@ -67,6 +69,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      # see: https://github.com/actions/runner-images/issues/10788
+      - uses: sbt/setup-sbt@v1
       - name: Coursier cache
         uses: coursier/cache-action@v6
       - name: Set APALACHE_HOME env
@@ -100,6 +104,8 @@ jobs:
         with:
           jvm: temurin:1.17
           apps: sbtn
+      # see: https://github.com/actions/runner-images/issues/10788
+      - uses: sbt/setup-sbt@v1
       - name: Set APALACHE_HOME env
         # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
         run: echo "APALACHE_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: sbt
+      - name: Install sbt
+        run: sudo apt-get install -y sbt
       - name: Check formatting
         run: make fmt-check
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,6 +173,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # see: https://github.com/actions/runner-images/issues/10788
+      - uses: sbt/setup-sbt@v1
       - name: Cache nix store
         # Workaround for cache action not playing well with permissions
         # See https://github.com/actions/cache/issues/324

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
       - name: Check formatting
         run: make fmt-check
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
         uses: coursier/setup-action@v1
         with:
           jvm: temurin:1.17
-          apps: sbtn
+          apps: sbt
       # see: https://github.com/actions/runner-images/issues/10788
       - uses: sbt/setup-sbt@v1
       - name: Set APALACHE_HOME env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: sbt
-      - name: Install sbt
-        run: sudo apt-get install -y sbt
+      # see: https://github.com/actions/runner-images/issues/10788
+      - uses: sbt/setup-sbt@v1
       - name: Check formatting
         run: make fmt-check
 


### PR DESCRIPTION
All of a sudden, `sbt` is not included by default: https://github.com/actions/runner-images/issues/10788. This PR should fix that.
