### PR TITLE
Add an inductive invariant for two-phase commit from the earlier experiments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache local m2 repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-sbt-${{ hashFiles('project/Dependencies.scala') }}

--- a/test/tla/MC20_TwoPhaseTypedInv.tla
+++ b/test/tla/MC20_TwoPhaseTypedInv.tla
@@ -1,0 +1,22 @@
+------------------------ MODULE MC20_TwoPhaseTypedInv -------------------------
+
+RM == {
+    "0_OF_RM", "1_OF_RM", "2_OF_RM", "3_OF_RM", "4_OF_RM", "5_OF_RM",
+    "6_OF_RM", "7_OF_RM", "8_OF_RM", "9_OF_RM", "10_OF_RM", "11_OF_RM",
+    "12_OF_RM", "13_OF_RM", "14_OF_RM", "15_OF_RM", "16_OF_RM", "17_OF_RM",
+    "18_OF_RM", "19_OF_RM"
+}
+
+VARIABLES
+  \* @type: RM -> Str;
+  rmState,       \* $rmState[rm]$ is the state of resource manager RM.
+  \* @type: Str;
+  tmState,       \* The state of the transaction manager.
+  \* @type: Set(RM);
+  tmPrepared,    \* The set of RMs from which the TM has received $"Prepared"$
+                 \* messages.
+  \* @type: Set($message);
+  msgs
+
+INSTANCE TwoPhaseTypedInv
+===============================================================================

--- a/test/tla/MC3_TwoPhaseTypedInv.tla
+++ b/test/tla/MC3_TwoPhaseTypedInv.tla
@@ -1,0 +1,17 @@
+------------------------- MODULE MC3_TwoPhaseTypedInv -------------------------
+
+RM == { "0_OF_RM", "1_OF_RM", "2_OF_RM" }
+
+VARIABLES
+  \* @type: RM -> Str;
+  rmState,       \* $rmState[rm]$ is the state of resource manager RM.
+  \* @type: Str;
+  tmState,       \* The state of the transaction manager.
+  \* @type: Set(RM);
+  tmPrepared,    \* The set of RMs from which the TM has received $"Prepared"$
+                 \* messages.
+  \* @type: Set($message);
+  msgs
+
+INSTANCE TwoPhaseTypedInv
+===============================================================================

--- a/test/tla/MC50_TwoPhaseTypedInv.tla
+++ b/test/tla/MC50_TwoPhaseTypedInv.tla
@@ -1,0 +1,27 @@
+------------------------ MODULE MC50_TwoPhaseTypedInv -------------------------
+
+RM == {
+    "0_OF_RM", "1_OF_RM", "2_OF_RM", "3_OF_RM", "4_OF_RM", "5_OF_RM",
+    "6_OF_RM", "7_OF_RM", "8_OF_RM", "9_OF_RM", "10_OF_RM", "11_OF_RM",
+    "12_OF_RM", "13_OF_RM", "14_OF_RM", "15_OF_RM", "16_OF_RM", "17_OF_RM",
+    "18_OF_RM", "19_OF_RM", "20_OF_RM", "21_OF_RM", "22_OF_RM", "23_OF_RM",
+    "24_OF_RM", "25_OF_RM", "26_OF_RM", "27_OF_RM", "28_OF_RM", "29_OF_RM",
+    "30_OF_RM", "31_OF_RM", "32_OF_RM", "33_OF_RM", "34_OF_RM", "35_OF_RM",
+    "36_OF_RM", "37_OF_RM", "38_OF_RM", "39_OF_RM", "40_OF_RM", "41_OF_RM",
+    "42_OF_RM", "43_OF_RM", "44_OF_RM", "45_OF_RM", "46_OF_RM", "47_OF_RM",
+    "48_OF_RM", "49_OF_RM"
+}
+
+VARIABLES
+  \* @type: RM -> Str;
+  rmState,       \* $rmState[rm]$ is the state of resource manager RM.
+  \* @type: Str;
+  tmState,       \* The state of the transaction manager.
+  \* @type: Set(RM);
+  tmPrepared,    \* The set of RMs from which the TM has received $"Prepared"$
+                 \* messages.
+  \* @type: Set($message);
+  msgs
+
+INSTANCE TwoPhaseTypedInv
+===============================================================================

--- a/test/tla/MC7_TwoPhaseTypedInv.tla
+++ b/test/tla/MC7_TwoPhaseTypedInv.tla
@@ -1,0 +1,17 @@
+------------------------- MODULE MC7_TwoPhaseTypedInv -------------------------
+
+RM == { "0_OF_RM", "1_OF_RM", "2_OF_RM", "3_OF_RM", "4_OF_RM", "5_OF_RM", "6_OF_RM" }
+
+VARIABLES
+  \* @type: RM -> Str;
+  rmState,       \* $rmState[rm]$ is the state of resource manager RM.
+  \* @type: Str;
+  tmState,       \* The state of the transaction manager.
+  \* @type: Set(RM);
+  tmPrepared,    \* The set of RMs from which the TM has received $"Prepared"$
+                 \* messages.
+  \* @type: Set($message);
+  msgs
+
+INSTANCE TwoPhaseTypedInv
+===============================================================================

--- a/test/tla/TwoPhaseTypedInv.tla
+++ b/test/tla/TwoPhaseTypedInv.tla
@@ -1,0 +1,37 @@
+------------------- MODULE TwoPhaseTypedInv ------------------
+EXTENDS TwoPhaseTyped
+
+IndInv ==
+    /\ TPTypeOK
+    /\ TCConsistent 
+    /\ (\E rm \in RM: rmState[rm] = "committed") => tmState = "committed"
+    /\ tmState = "committed" => /\ tmPrepared = RM
+                                /\ \A rm \in RM: rmState[rm] \notin {"working", "aborted"}
+                                /\ MkCommit \in msgs
+    /\ tmState = "aborted" => MkAbort \in msgs
+    /\ \A rm \in RM:
+      /\ rm \in tmPrepared =>
+        /\ rmState[rm] /= "working"
+        /\ MkPrepared(rm) \in msgs
+      /\ rmState[rm] = "working" => MkPrepared(rm) \notin msgs
+      /\ MkPrepared(rm) \in msgs => rmState[rm] /= "working" 
+      /\ rmState[rm] = "aborted" =>
+        \/ MkAbort \in msgs
+        \/ MkPrepared(rm) \notin msgs
+    /\ MkAbort \in msgs =>
+        \* it is either the TM or an RM who was in the "working" state
+        \/ tmState = "aborted"
+        \/ \E rm \in RM:
+          /\ rmState[rm] = "aborted"
+          /\ rm \notin tmPrepared
+          /\ MkPrepared(rm) \notin msgs                 
+    /\ MkCommit \in msgs =>
+        /\ tmPrepared = RM
+        /\ \/ tmState = "committed"
+           \/ \E rm \in RM: rmState[rm] = "committed" 
+
+InitInv ==
+    /\ TPTypeOK
+    /\ IndInv
+
+==============================================================


### PR DESCRIPTION
This PR adds the inductive invariant for two-phase commit. This inductive invariant was available in the early [apalache tests](https://github.com/apalache-mc/apalache-tests/blob/master/performance/two-phase/APATwoPhase.tla). Adding it to the main tests, to keep it for the future reference.

Also, fixing the checkout version in the github workflow.