### PR TITLE
Constant simplifications for sets of literals

### DIFF
--- a/.unreleased/features/3134-set-simplifications.md
+++ b/.unreleased/features/3134-set-simplifications.md
@@ -1,0 +1,5 @@
+Simplify set operators over literals:
+ - Set union `{1, 2, 3} \cup {4}` becomes `{1, 2, 3, 4}`
+ - Set difference `{3, 4} \ {3}` becomes `{4}`
+ - Set union `{1, 2, 3} \cap {1, 3}` becomes `{1, 3}`
+ - Set cardinality `Cardinality({3, 4, 5})` becomes 3

--- a/test/tla/Bug931.tla
+++ b/test/tla/Bug931.tla
@@ -3,6 +3,6 @@ EXTENDS  FiniteSets
 
 Init == TRUE
 Next == TRUE
-Inv == Cardinality({}) /= 1
+Inv == Cardinality({{}}) = 1
 
 ===================================

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2314,7 +2314,7 @@ Test that the model checker nicely complains about unresolved polymorphism.
 ```sh
 $ apalache-mc check --inv=Inv Bug931.tla | sed 's/[IEW]@.*//'
 ...
-Bug931.tla:6:20-6:21: unexpected expression: Expected a non-polymorphic type, found: Set(b)
+Bug931.tla:6:21-6:22: unexpected expression: Expected a non-polymorphic type, found: Set(d)
 ...
 EXITCODE: ERROR (255)
 ```

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
-import at.forsyte.apalache.tla.types.{BuilderT, BuilderUT, tlaU => tla}
+import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderT, BuilderUT}
 
 import scala.collection.immutable.SortedSet
 

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -319,6 +319,7 @@ abstract class ConstSimplifierBase {
           literals.map {
             case s: String  => ValEx(TlaStr(s))(strTag)
             case i: Int     => ValEx(TlaInt(i))(intTag)
+            case i: BigInt  => ValEx(TlaInt(i))(intTag)
             case b: Boolean => ValEx(TlaBool(b))(boolTag)
           }: _*)(typeTag)
     }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -237,8 +237,7 @@ abstract class ConstSimplifierBase {
       emptySet(funSet.typeTag)
 
     // S \cup T when both S and T contain only literals
-    case originalExpr @ OperEx(TlaSetOper.cup,
-            OperEx(TlaSetOper.enumSet, args1 @ _*),
+    case originalExpr @ OperEx(TlaSetOper.cup, OperEx(TlaSetOper.enumSet, args1 @ _*),
             OperEx(TlaSetOper.enumSet, args2 @ _*)) =>
       val literals1 = extractLiterals(args1)
       val literals2 = extractLiterals(args2)
@@ -252,8 +251,7 @@ abstract class ConstSimplifierBase {
       }
 
     // S \cap T when both S and T contain only literals
-    case originalExpr @ OperEx(TlaSetOper.cap,
-            OperEx(TlaSetOper.enumSet, args1 @ _*),
+    case originalExpr @ OperEx(TlaSetOper.cap, OperEx(TlaSetOper.enumSet, args1 @ _*),
             OperEx(TlaSetOper.enumSet, args2 @ _*)) =>
       val literals1 = extractLiterals(args1)
       val literals2 = extractLiterals(args2)
@@ -262,13 +260,12 @@ abstract class ConstSimplifierBase {
         originalExpr
       } else {
         // all elements are literals, so we can statically compute the intersection
-        val setIntersection = (literals1.flatten intersect literals2.flatten).distinct
+        val setIntersection = (literals1.flatten.intersect(literals2.flatten)).distinct
         literalsToSet(setIntersection, originalExpr.typeTag)
       }
 
     // S \ T when both S and T contain only literals
-    case originalExpr @ OperEx(TlaSetOper.setminus,
-            OperEx(TlaSetOper.enumSet, args1 @ _*),
+    case originalExpr @ OperEx(TlaSetOper.setminus, OperEx(TlaSetOper.enumSet, args1 @ _*),
             OperEx(TlaSetOper.enumSet, args2 @ _*)) =>
       val literals1 = extractLiterals(args1)
       val literals2 = extractLiterals(args2)
@@ -277,7 +274,7 @@ abstract class ConstSimplifierBase {
         originalExpr
       } else {
         // all elements are literals, so we can statically compute the set difference
-        val setDifference = (literals1.flatten diff literals2.flatten).distinct
+        val setDifference = (literals1.flatten.diff(literals2.flatten)).distinct
         literalsToSet(setDifference, originalExpr.typeTag)
       }
 
@@ -319,11 +316,11 @@ abstract class ConstSimplifierBase {
       emptySet(typeTag)
     } else {
       OperEx(TlaSetOper.enumSet,
-        literals.map {
-          case s: String => ValEx(TlaStr(s))(strTag)
-          case i: Int => ValEx(TlaInt(i))(intTag)
-          case b: Boolean => ValEx(TlaBool(b))(boolTag)
-        }: _*)(typeTag)
+          literals.map {
+            case s: String  => ValEx(TlaStr(s))(strTag)
+            case i: Int     => ValEx(TlaInt(i))(intTag)
+            case b: Boolean => ValEx(TlaBool(b))(boolTag)
+          }: _*)(typeTag)
     }
   }
 }

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -260,7 +260,7 @@ abstract class ConstSimplifierBase {
         originalExpr
       } else {
         // all elements are literals, so we can statically compute the intersection
-        val setIntersection = (literals1.flatten.intersect(literals2.flatten)).distinct
+        val setIntersection = ((literals1.flatten.distinct.intersect(literals2.flatten.distinct))).distinct
         literalsToSet(setIntersection, originalExpr.typeTag)
       }
 
@@ -274,7 +274,7 @@ abstract class ConstSimplifierBase {
         originalExpr
       } else {
         // all elements are literals, so we can statically compute the set difference
-        val setDifference = (literals1.flatten.diff(literals2.flatten)).distinct
+        val setDifference = ((literals1.flatten.distinct.diff(literals2.flatten.distinct))).distinct
         literalsToSet(setDifference, originalExpr.typeTag)
       }
 
@@ -301,6 +301,8 @@ abstract class ConstSimplifierBase {
     ex.map(simplifyShallow) // when using TBuilderInstruction
 
   // extract basic literals from the arguments of a set constructor
+  // returns a sequence of Some(literal) or None if the argument is not a literal
+  // A literal is either a string, an integer, or a boolean.
   private def extractLiterals(args: Seq[TlaEx]): Seq[Option[Any]] = {
     args.map {
       case ValEx(TlaStr(s))  => Some(s)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ExprOptimizer.scala
@@ -1,13 +1,12 @@
 package at.forsyte.apalache.tla.pp
 
+import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.convenience.tla
+import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.transformations.standard.{DeepCopy, FlatLanguagePred, ReplaceFixed}
 import at.forsyte.apalache.tla.lir.transformations.{LanguageWatchdog, TlaExTransformation, TransformationTracker}
 import at.forsyte.apalache.tla.lir.values.{TlaInt, TlaStr}
-import TypedPredefs._
-
 import com.google.inject.Singleton
 
 /**

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -20,6 +20,7 @@ import org.scalatestplus.scalacheck.Checkers
 @RunWith(classOf[JUnitRunner])
 class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Checkers with AppendedClues with Matchers {
   private val intT = IntT1
+  private val boolSetT = SetT1(BoolT1)
   private val intSetT = SetT1(IntT1)
   private val strSetT = SetT1(StrT1)
 
@@ -451,21 +452,57 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
     check(prop, minSuccessful(1000), sizeRange(8))
   }
 
-  test("""{"a", "b", "c"} \\union {"d"} becomes {"a", "b", "c", "d", "e"}""") {
+  test("""{"a", "b", "c"} \\union {"e", "d"} becomes {"a", "b", "c", "d", "e"}""") {
     val set1 = enumSet(str("a"), str("b"), str("c")).as(strSetT)
-    val set2 = enumSet(str("d"), str("e")).as(strSetT)
+    val set2 = enumSet(str("e"), str("d")).as(strSetT)
     val unionSet = cup(set1, set2).as(strSetT)
     val output = simplifier.apply(unionSet)
     val expected = enumSet(str("a"), str("b"), str("c"), str("d"), str("e")).as(strSetT)
     assert(output == expected)
   }
 
-  test("""{"a", "b", "c"} \ {"b"} becomes {"a", "c"}""") {
+  test("""{2, 4, 2, 5} \\union {3, 6} becomes {2, 3, 4, 5, 6}""") {
+    val set1 = enumSet(int(2), int(4), int(2), int(5)).as(intSetT)
+    val set2 = enumSet(int(3), int(6)).as(intSetT)
+    val unionSet = cup(set1, set2).as(intSetT)
+    val output = simplifier.apply(unionSet)
+    val expected = enumSet(int(2), int(3), int(4), int(5), int(6)).as(intSetT)
+    assert(output == expected)
+  }
+
+  test("""{TRUE} \\union {FALSE} becomes {FALSE, TRUE}""") {
+    val set1 = enumSet(bool(true)).as(boolSetT)
+    val set2 = enumSet(bool(false)).as(boolSetT)
+    val unionSet = cup(set1, set2).as(boolSetT)
+    val output = simplifier.apply(unionSet)
+    val expected = enumSet(bool(false), bool(true)).as(boolSetT)
+    assert(output == expected)
+  }
+
+  test("""{"a", "b", "c"} \\ {"b"} becomes {"a", "c"}""") {
     val set1 = enumSet(str("a"), str("b"), str("c")).as(strSetT)
     val set2 = enumSet(str("b")).as(strSetT)
     val unionSet = setminus(set1, set2).as(strSetT)
     val output = simplifier.apply(unionSet)
     val expected = enumSet(str("a"), str("c")).as(strSetT)
+    assert(output == expected)
+  }
+
+  test("""{2, 4, 2, 5} \\ {2} becomes {4, 5}""") {
+    val set1 = enumSet(int(2), int(4), int(2), int(5)).as(intSetT)
+    val set2 = enumSet(int(2)).as(intSetT)
+    val diffSet = setminus(set1, set2).as(intSetT)
+    val output = simplifier.apply(diffSet)
+    val expected = enumSet(int(4), int(5)).as(intSetT)
+    assert(output == expected)
+  }
+
+  test("""{TRUE, FALSE} \\ {TRUE} becomes {FALSE}""") {
+    val set1 = enumSet(bool(true), bool(false)).as(boolSetT)
+    val set2 = enumSet(bool(true)).as(boolSetT)
+    val diffSet = setminus(set1, set2).as(boolSetT)
+    val output = simplifier.apply(diffSet)
+    val expected = enumSet(bool(false)).as(boolSetT)
     assert(output == expected)
   }
 
@@ -475,6 +512,24 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
     val unionSet = cap(set1, set2).as(strSetT)
     val output = simplifier.apply(unionSet)
     val expected = enumSet(str("a")).as(strSetT)
+    assert(output == expected)
+  }
+
+  test("""{2, 4, 2, 5} \\cap {5, 2} becomes {2, 5}""") {
+    val set1 = enumSet(int(2), int(4), int(2), int(5)).as(intSetT)
+    val set2 = enumSet(int(5), int(2)).as(intSetT)
+    val intersection = cap(set1, set2).as(intSetT)
+    val output = simplifier.apply(intersection)
+    val expected = enumSet(int(2), int(5)).as(intSetT)
+    assert(output == expected)
+  }
+
+  test("""{TRUE} \\cap {FALSE} becomes {}""") {
+    val set1 = enumSet(bool(true)).as(boolSetT)
+    val set2 = enumSet(bool(false)).as(boolSetT)
+    val intersection = cap(set1, set2).as(boolSetT)
+    val output = simplifier.apply(intersection)
+    val expected = enumSet().as(boolSetT)
     assert(output == expected)
   }
 

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir.TypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience._
 import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.transformations.impl.{IdleTracker, TrackerWithListeners}
+import at.forsyte.apalache.tla.lir.transformations.impl.IdleTracker
 import at.forsyte.apalache.tla.lir._
 import org.junit.runner.RunWith
 import org.scalacheck.Gen

--- a/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
+++ b/tla-pp/src/test/scala/at/forsyte/apalache/tla/pp/TestConstSimplifier.scala
@@ -451,6 +451,33 @@ class TestConstSimplifier extends AnyFunSuite with BeforeAndAfterEach with Check
     check(prop, minSuccessful(1000), sizeRange(8))
   }
 
+  test("""{"a", "b", "c"} \\union {"d"} becomes {"a", "b", "c", "d", "e"}""") {
+    val set1 = enumSet(str("a"), str("b"), str("c")).as(strSetT)
+    val set2 = enumSet(str("d"), str("e")).as(strSetT)
+    val unionSet = cup(set1, set2).as(strSetT)
+    val output = simplifier.apply(unionSet)
+    val expected = enumSet(str("a"), str("b"), str("c"), str("d"), str("e")).as(strSetT)
+    assert(output == expected)
+  }
+
+  test("""{"a", "b", "c"} \ {"b"} becomes {"a", "c"}""") {
+    val set1 = enumSet(str("a"), str("b"), str("c")).as(strSetT)
+    val set2 = enumSet(str("b")).as(strSetT)
+    val unionSet = setminus(set1, set2).as(strSetT)
+    val output = simplifier.apply(unionSet)
+    val expected = enumSet(str("a"), str("c")).as(strSetT)
+    assert(output == expected)
+  }
+
+  test("""{"a", "b", "c"} \\cap {"a", "d"} becomes {"a"}""") {
+    val set1 = enumSet(str("a"), str("b"), str("c")).as(strSetT)
+    val set2 = enumSet(str("a"), str("d")).as(strSetT)
+    val unionSet = cap(set1, set2).as(strSetT)
+    val output = simplifier.apply(unionSet)
+    val expected = enumSet(str("a")).as(strSetT)
+    assert(output == expected)
+  }
+
   test("""Cardinality({"a", "b", "c"}) becomes 3""") {
     val input = card(enumSet(str("a"), str("b"), str("c")).as(strSetT)).as(intT)
     val output = simplifier.apply(input)


### PR DESCRIPTION
Simplify set operators over literals:                                                                                   
 - Set union `{1, 2, 3} \cup {4}` becomes `{1, 2, 3, 4}`
 - Set difference `{3, 4} \ {3}` becomes `{4}`
 - Set union `{1, 2, 3} \cap {1, 3}` becomes `{1, 3}`
 - Set cardinality `Cardinality({3, 4, 5})` becomes 3

These optimizations happen to be quite useful, especially, in conjunction with the operator `..`, e.g., `0..Cardinality({ 1, 2, 3} \union {4})`.

The set of optimizations is incomplete. It would be great to have a more general rewriting framework in the future.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
