### PR TITLE
Update the Quint version of `apalache::generate`

### DIFF
--- a/.unreleased/breaking-changes/3138-apalache-generate.md
+++ b/.unreleased/breaking-changes/3138-apalache-generate.md
@@ -1,0 +1,1 @@
+Changed the intermediate representation of Quint's `apalache::generate` (#3138)

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/quint/Quint.scala
@@ -659,7 +659,7 @@ class Quint(quintOutput: QuintOutput) {
   //   ~~>
   //   \E name \in domain: scope
   //
-  //   nondet name = generate(sz, typeSet); scope
+  //   nondet name: type = generate(sz); scope
   //   ~~>
   //   \E name \in { Apalache!Gen(sz) }: scope
   private val nondetBinding: (QuintDef.QuintOpDef, QuintEx) => NullaryOpReader[TBuilderInstruction] = {
@@ -671,7 +671,7 @@ class Quint(quintOutput: QuintOutput) {
         tlaScope <- tlaExpression(scope)
       } yield tla.exists(tlaName, tlaDomain, tlaScope)
 
-    case (QuintDef.QuintOpDef(_, name, "nondet", QuintApp(id, "generate", Seq(bound, _))), scope) =>
+    case (QuintDef.QuintOpDef(_, name, "nondet", QuintApp(id, "apalache::generate", Seq(bound))), scope) =>
       val elemType = typeConv.convert(types(id).typ)
       val boundIntConst = intFromExpr(bound)
       if (boundIntConst.isEmpty) {

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/quint/TestQuintEx.scala
@@ -173,7 +173,7 @@ class TestQuintEx extends AnyFunSuite {
     val oneOfSet = app("oneOf", intSet)(QuintIntT())
     val nondetBinding =
       e(QuintLet(uid, d(QuintDef.QuintOpDef(uid, "n", "nondet", oneOfSet), QuintIntT()), nIsGreaterThan0), QuintBoolT())
-    val generateSet = app("generate", _42, app("Set", _42)(QuintSetT(QuintIntT())))(QuintSetT(QuintIntT()))
+    val generateSet = app("apalache::generate", _42)(QuintSetT(QuintIntT()))
     val nondetGenerateId = uid
     val appGenSet =
       app("eq", e(QuintName(uid, "S"), QuintSetT(QuintIntT())), app("Set")(QuintSetT(QuintIntT())))(QuintBoolT())


### PR DESCRIPTION
Update the intermediate representation of Quint's `apalache::generate`.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/informalsystems/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
