### PR TITLE
Relax bound expressions in apalache::generate

### DIFF
--- a/.unreleased/features/3141-relax-generate.md
+++ b/.unreleased/features/3141-relax-generate.md
@@ -1,0 +1,1 @@
+Constant expressions are now allowed in `apalache::generate` when translating Quint (#3141)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateDecoder.scala
@@ -272,7 +272,7 @@ trait TestSymbStateDecoder extends RewriterBase {
 
   test("decode gen: Regression #1 for #2702") { rewriterType: SMTEncoding =>
     val valName = tla.name("gen", SetT1(IntT1))
-    val genEx = tla.gen(1, SetT1(IntT1))
+    val genEx = tla.gen(tla.int(1), SetT1(IntT1))
     val x = tla.name("x", IntT1)
     val cond = tla.forall(x, valName, tla.eql(x, tla.int(0)))
 
@@ -301,7 +301,7 @@ trait TestSymbStateDecoder extends RewriterBase {
 
   test("decode gen: Regression #2 for #2702") { rewriterType: SMTEncoding =>
     val valName = tla.name("gen", SetT1(IntT1))
-    val genEx = tla.gen(1, SetT1(IntT1))
+    val genEx = tla.gen(tla.int(1), SetT1(IntT1))
     val x = tla.name("x", IntT1)
     val cond = tla.forall(x, valName, tla.neql(x, tla.int(42)))
 

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/json/BuilderCallByName.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/json/BuilderCallByName.scala
@@ -343,13 +343,8 @@ object BuilderCallByName {
         val Seq(x, e) = args
         tla.assign(x, e)
       case ApalacheOper.gen =>
-        val Seq(nEx): Seq[TlaEx] = args
-        nEx match {
-          case ValEx(TlaInt(n)) =>
-            tla.gen(n, tt1)
-          // should never happen, for case-completeness
-          case _ => throw new JsonDeserializationError(s"${oper.name} requires an integer argument.")
-        }
+        val Seq(boundEx) = args
+        tla.gen(boundEx, tt1)
       case ApalacheOper.skolem =>
         val Seq(ex) = args
         tla.skolem(ex)

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -253,7 +253,7 @@ abstract class ConstSimplifierBase {
       val funSetT = TlaType1.fromTypeTag(funSet.typeTag)
       funSetT match {
         case SetT1(FunT1(domElemT, cdmElemT)) =>
-          val mockCdm = tla.gen(1, SetT1(cdmElemT))
+          val mockCdm = tla.gen(ValEx(TlaInt(1))(intTag), SetT1(cdmElemT))
           tla.funSet(tla.emptySet(domElemT), mockCdm)
         case t =>
           throw new TypingException(s"Function-set $funSet should have a set-of-functions type, found: $t", funSet.ID)

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/ApalacheBuilder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/subbuilder/ApalacheBuilder.scala
@@ -4,7 +4,6 @@ import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.typecomp.BuilderUtil._
 import at.forsyte.apalache.tla.typecomp._
 import at.forsyte.apalache.tla.typecomp.unsafe.UnsafeApalacheBuilder
-import scalaz.Scalaz._
 import scalaz._
 
 /**
@@ -28,15 +27,18 @@ trait ApalacheBuilder {
     binaryFromUnsafe(lhs, rhs)(unsafeBuilder.assign)
 
   /**
-   * {{{Gen(n): t}}}
+   * {{{Gen(boundEx): returnType}}}
    *
-   * Can return any type of expression, so the type must be manually provided, as it cannot be inferred from the
-   * argument.
+   * Produce a value generator, given a bound expression and the expected return type.
    *
-   * @param n
-   *   must be positive
+   * @param boundEx
+   *   a bound on the number of generated expressions; it must be reducible to a constant expression
+   * @param returnType
+   *   the return type of the produced expression
    */
-  def gen(n: BigInt, t: TlaType1): TBuilderInstruction = unsafeBuilder.gen(n, t).point[TBuilderInternalState]
+  def gen(boundEx: TBuilderInstruction, returnType: TlaType1): TBuilderInstruction = {
+    boundEx.map(unsafeBuilder.gen(_, returnType))
+  }
 
   /**
    * {{{Repeat(F, N, x): t}}}

--- a/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeApalacheBuilder.scala
+++ b/tlair/src/main/scala/at/forsyte/apalache/tla/typecomp/unsafe/UnsafeApalacheBuilder.scala
@@ -28,17 +28,16 @@ trait UnsafeApalacheBuilder extends ProtoBuilder with UnsafeLiteralAndNameBuilde
   }
 
   /**
-   * {{{Gen(n): t}}}
+   * {{{Gen(boundEx): returnType}}}
    *
-   * Can return any type of expression, so the type must be manually provided, as it cannot be inferred from the
-   * argument.
+   * Produce an Apalache generator for a bound expression and the return type. Can return any type of expression, so the
+   * type must be manually provided, as it cannot be inferred from the argument.
    *
-   * @param n
-   *   must be positive
+   * @param boundEx
+   *   a bound expression, which must be constant after all simplifications
    */
-  def gen(n: BigInt, t: TlaType1): TlaEx = {
-    if (strict) require(n > 0, s"Expected n to be positive, found $n.")
-    OperEx(ApalacheOper.gen, int(n))(Typed(t))
+  def gen(boundEx: TlaEx, returnType: TlaType1): TlaEx = {
+    OperEx(ApalacheOper.gen, boundEx)(Typed(returnType))
   }
 
   /**

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestApalacheBuilder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestApalacheBuilder.scala
@@ -81,19 +81,6 @@ class TestApalacheBuilder extends BuilderTest {
             resultIsExpected,
         )
     )
-
-    // throws on n <= 0
-    assertThrows[IllegalArgumentException] {
-      build(
-          builder.gen(0, IntT1)
-      )
-    }
-
-    assertThrows[IllegalArgumentException] {
-      build(
-          builder.gen(-1, IntT1)
-      )
-    }
   }
 
   test("skolem") {

--- a/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestApalacheBuilder.scala
+++ b/tlair/src/test/scala/at/forsyte/apalache/tla/typecomp/TestApalacheBuilder.scala
@@ -71,7 +71,7 @@ class TestApalacheBuilder extends BuilderTest {
     )
 
     // We don't want generators producing BigInt, so we have to manually cast the parameter argument
-    def genFromInt(i: Int, t: TlaType1): TBuilderInstruction = builder.gen(BigInt.int2bigInt(i), t)
+    def genFromInt(i: Int, t: TlaType1): TBuilderInstruction = builder.gen(i, t)
 
     checkRun(Generators.positiveIntAndTypeGen)(
         runBinary(


### PR DESCRIPTION
Currently, `apalache::generate` expects a constant integer and throws an exception otherwise. This is counterproductive, as there are plenty of opportunities to simplify the bound expression in the preprocessing passes.

This PR relaxes the requirement to the bound expression in `apalache::generate`. If it is not reduced to a constant expression while reaching the rewriting engine, then an error is produced. Basically, we increase the set of accepted expressions, while the UX is about the same for the end user.

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality