### PR TITLE
Fix 2973: `Gen` should not be cached 

### DIFF
--- a/.unreleased/breaking-changes/fix-gen3147.md
+++ b/.unreleased/breaking-changes/fix-gen3147.md
@@ -1,0 +1,1 @@
+Not caching `Apalache!Gen(n)` as it breaks completeness (#3147)

--- a/test/tla/Bug2973.tla
+++ b/test/tla/Bug2973.tla
@@ -1,0 +1,27 @@
+----------------------------- MODULE Bug2973 -----------------------------
+\* A regression test for the case of passing the same expression to Gen.
+\* Before the fix, it was producing the same constant
+\* for a and b in InitSameArgs.
+EXTENDS Apalache, Integers
+
+VARIABLES 
+    \* @type: Int;
+    a,
+    \* @type: Int;
+    b
+
+\* this should not produce a deadlock, as a and b are different constants
+InitSameArgs == 
+    /\ a = Gen(1)
+    /\ b = Gen(1)
+    /\ a /= b
+
+\* this should not produce a deadlock, as a and b are different constants
+InitDifferentArgs == 
+    /\ a = Gen(1)
+    /\ b = Gen(2)
+    /\ a /= b
+
+Next == UNCHANGED <<a,b>>
+=============================================================================
+

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2895,6 +2895,30 @@ The outcome is: NoError
 EXITCODE: OK
 ```
 
+### check Bug2973.tla with InitSameArgs
+
+A regression test for ensuring that `Apalache!Gen(_)` is not cached by the rewriter.
+
+```sh
+$ apalache-mc check --length=1 --init=InitSameArgs test/tla/Bug2973.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+EXITCODE: OK
+```
+
+### check Bug2973.tla with InitDifferentArgs
+
+A regression test for ensuring that `Apalache!Gen(_)` is not cached by the rewriter.
+
+```sh
+$ apalache-mc check --length=1 --init=InitDifferentArgs test/tla/Bug2973.tla | sed 's/I@.*//'
+...
+The outcome is: NoError
+...
+EXITCODE: OK
+```
+
 ## running the typecheck command
 
 ### typecheck Empty.tla reports no error

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2900,7 +2900,7 @@ EXITCODE: OK
 A regression test for ensuring that `Apalache!Gen(_)` is not cached by the rewriter.
 
 ```sh
-$ apalache-mc check --length=1 --init=InitSameArgs test/tla/Bug2973.tla | sed 's/I@.*//'
+$ apalache-mc check --length=1 --init=InitSameArgs Bug2973.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...
@@ -2912,7 +2912,7 @@ EXITCODE: OK
 A regression test for ensuring that `Apalache!Gen(_)` is not cached by the rewriter.
 
 ```sh
-$ apalache-mc check --length=1 --init=InitDifferentArgs test/tla/Bug2973.tla | sed 's/I@.*//'
+$ apalache-mc check --length=1 --init=InitDifferentArgs Bug2973.tla | sed 's/I@.*//'
 ...
 The outcome is: NoError
 ...

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/analyses/ExprGradeAnalysis.scala
@@ -1,7 +1,7 @@
 package at.forsyte.apalache.tla.bmcmt.analyses
 
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.lir.oper.{TlaActionOper, TlaBoolOper, TlaTempOper}
+import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaActionOper, TlaBoolOper, TlaTempOper}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import com.google.inject.Inject
 
@@ -41,6 +41,10 @@ class ExprGradeAnalysis @Inject() (val store: ExprGradeStoreImpl) {
           update(e, ExprGrade.StateFree)
         else
           update(e, ExprGrade.StateBound)
+
+      case OperEx(ApalacheOper.gen, _) =>
+        // Apalache!Gen(n) should not be cached, as it produces a new set of constants on each call
+        update(e, ExprGrade.NonCacheable)
 
       case OperEx(TlaActionOper.prime, arg) =>
         // e.g., x'


### PR DESCRIPTION
Closes #2973. `Apalache!Gen` is declared as uncacheable in preprocessing.

- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
