### PR TITLE
Demote the generic types checker

### DIFF
--- a/.unreleased/breaking-changes/demote-generics-error.md
+++ b/.unreleased/breaking-changes/demote-generics-error.md
@@ -1,0 +1,1 @@
+Report a warning instead of an error when generic types are not tight (#3151)

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerPassImpl.scala
@@ -51,7 +51,13 @@ class EtcTypeCheckerPassImpl @Inject() (
     val loggingListener = new LoggingTypeCheckerListener(sourceStore, changeListener, inferPoly)
     val recordingListener = new RecordingTypeCheckerListener(sourceStore, changeListener)
     val listener = new MultiTypeCheckerListener(loggingListener, recordingListener)
-    if (tool.check(listener, tlaModule)) {
+    val result = tool.check(listener, tlaModule)
+    if (recordingListener.getWarnings().nonEmpty) {
+        logger.warn(" > Snowcat has some warnings:")
+        recordingListener.getWarnings().foreach { case (loc, msg) => logger.warn(s" > $loc: $msg") }
+    }
+
+    if (result) {
       val transformer = new TypeRewriter(tracker, defaultTag)(recordingListener.toMap)
       val taggedDecls = tlaModule.declarations.map(transformer(_))
       val newModule = TlaModule(tlaModule.name, taggedDecls)

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerPassImpl.scala
@@ -51,24 +51,24 @@ class EtcTypeCheckerPassImpl @Inject() (
     val loggingListener = new LoggingTypeCheckerListener(sourceStore, changeListener, inferPoly)
     val recordingListener = new RecordingTypeCheckerListener(sourceStore, changeListener)
     val listener = new MultiTypeCheckerListener(loggingListener, recordingListener)
-    val result = tool.check(listener, tlaModule)
-    if (recordingListener.getWarnings().nonEmpty) {
-      logger.warn(" > Snowcat has some warnings:")
-      recordingListener.getWarnings().foreach { case (loc, msg) => logger.warn(s" > $loc: $msg") }
-    }
-
-    if (result) {
+    if (!tool.check(listener, tlaModule)) {
+      logger.info(" > Snowcat asks you to fix the types. Meow.")
+      passFailure(recordingListener.getErrors(), ExitCodes.ERROR_TYPECHECK)
+    } else {
       val transformer = new TypeRewriter(tracker, defaultTag)(recordingListener.toMap)
       val taggedDecls = tlaModule.declarations.map(transformer(_))
       val newModule = TlaModule(tlaModule.name, taggedDecls)
-      logger.info(" > Your types are purrfect!")
+      if (recordingListener.getWarnings().isEmpty) {
+        logger.info(" > Your types are purrfect!")
+      } else {
+        logger.warn(" > Snowcat has some warnings:")
+        recordingListener.getWarnings().foreach { case (loc, msg) => logger.warn(s" > $loc: $msg") }
+      }
+
       logger.info(if (isTypeCoverageComplete) " > All expressions are typed" else " > Some expressions are untyped")
       writeOut(writerFactory, newModule)
       utils.writeToOutput(newModule, options, writerFactory, logger, sourceStore)
       Right(newModule)
-    } else {
-      logger.info(" > Snowcat asks you to fix the types. Meow.")
-      passFailure(recordingListener.getErrors(), ExitCodes.ERROR_TYPECHECK)
     }
   }
 

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerPassImpl.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/EtcTypeCheckerPassImpl.scala
@@ -53,8 +53,8 @@ class EtcTypeCheckerPassImpl @Inject() (
     val listener = new MultiTypeCheckerListener(loggingListener, recordingListener)
     val result = tool.check(listener, tlaModule)
     if (recordingListener.getWarnings().nonEmpty) {
-        logger.warn(" > Snowcat has some warnings:")
-        recordingListener.getWarnings().foreach { case (loc, msg) => logger.warn(s" > $loc: $msg") }
+      logger.warn(" > Snowcat has some warnings:")
+      recordingListener.getWarnings().foreach { case (loc, msg) => logger.warn(s" > $loc: $msg") }
     }
 
     if (result) {

--- a/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/LoggingTypeCheckerListener.scala
+++ b/passes/src/main/scala/at/forsyte/apalache/tla/passes/typecheck/LoggingTypeCheckerListener.scala
@@ -41,4 +41,16 @@ class LoggingTypeCheckerListener(
   override def onTypeError(sourceRef: EtcRef, message: String): Unit = {
     logger.error("[%s]: %s".format(findLoc(sourceRef.tlaId), message))
   }
+
+  /**
+   * This method is called when the type checker finds a type warning.
+   *
+   * @param sourceRef
+   *   a reference to the source expression; this one does not have to be exact
+   * @param message
+   *   the warning description
+   */
+  override def onTypeWarn(sourceRef: EtcRef, message: String): Unit = {
+    logger.debug("[%s]: %s".format(findLoc(sourceRef.tlaId), message))
+  }
 }

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3600,7 +3600,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck PolyTooGeneral.tla | sed 's/[IEW]@.*//'
 ...
-[PolyTooGeneral.tla:6:1-6:10]: Id's type annotation ((c) => b) is too general, inferred: ((a) => a)
+> [PolyTooGeneral.tla:6:1-6:10]: Id's type annotation ((c) => b) is too general, inferred: ((a) => a)
 ...
 EXITCODE: OK
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3602,7 +3602,7 @@ $ apalache-mc typecheck PolyTooGeneral.tla | sed 's/[IEW]@.*//'
 ...
 [PolyTooGeneral.tla:6:1-6:10]: Id's type annotation ((c) => b) is too general, inferred: ((a) => a)
 ...
-EXITCODE: ERROR (120)
+EXITCODE: OK
 ```
 
 ### typecheck PrintTypes

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3600,7 +3600,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck PolyTooGeneral.tla | sed 's/[IEW]@.*//'
 ...
- > [PolyTooGeneral.tla:6:1-6:10]: Id's type annotation ((c) => b) is too general, inferred: ((a) => a)
+ > PolyTooGeneral.tla:6:1-6:10: Id's type annotation ((c) => b) is too general, inferred: ((a) => a)
 ...
 EXITCODE: OK
 ```

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -3600,7 +3600,7 @@ EXITCODE: OK
 ```sh
 $ apalache-mc typecheck PolyTooGeneral.tla | sed 's/[IEW]@.*//'
 ...
-> [PolyTooGeneral.tla:6:1-6:10]: Id's type annotation ((c) => b) is too general, inferred: ((a) => a)
+ > [PolyTooGeneral.tla:6:1-6:10]: Id's type annotation ((c) => b) is too general, inferred: ((a) => a)
 ...
 EXITCODE: OK
 ```

--- a/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/DefaultTypeCheckerListener.scala
+++ b/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/DefaultTypeCheckerListener.scala
@@ -30,4 +30,14 @@ class DefaultTypeCheckerListener extends TypeCheckerListener {
    *   the error description
    */
   override def onTypeError(sourceRef: EtcRef, message: String): Unit = {}
+
+  /**
+   * This method is called when the type checker finds a type warning.
+   *
+   * @param sourceRef
+   *   a reference to the source expression
+   * @param message
+   *   the warning description
+   */
+  override def onTypeWarn(sourceRef: EtcRef, message: String): Unit = {}
 }

--- a/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/MultiTypeCheckerListener.scala
+++ b/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/MultiTypeCheckerListener.scala
@@ -21,4 +21,10 @@ class MultiTypeCheckerListener(subscribers: TypeCheckerListener*) extends TypeCh
       s.onTypeError(sourceRef, message)
     }
   }
+
+  override def onTypeWarn(sourceRef: EtcRef, message: String): Unit = {
+    for (s <- subscribers) {
+      s.onTypeWarn(sourceRef, message)
+    }
+  }
 }

--- a/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/TypeCheckerListener.scala
+++ b/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/TypeCheckerListener.scala
@@ -31,7 +31,6 @@ trait TypeCheckerListener {
    */
   def onTypeError(sourceRef: EtcRef, message: String): Unit
 
-
   /**
    * This method is called when the type checker finds a type warning.
    * @param sourceRef

--- a/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/TypeCheckerListener.scala
+++ b/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/TypeCheckerListener.scala
@@ -30,4 +30,14 @@ trait TypeCheckerListener {
    *   the error description
    */
   def onTypeError(sourceRef: EtcRef, message: String): Unit
+
+
+  /**
+   * This method is called when the type checker finds a type warning.
+   * @param sourceRef
+   *   a reference to the source expression; this one does not have to be exact
+   * @param message
+   *   the warning description
+   */
+  def onTypeWarn(sourceRef: EtcRef, message: String): Unit
 }

--- a/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
+++ b/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/etc/EtcTypeChecker.scala
@@ -330,10 +330,9 @@ class EtcTypeChecker(varPool: TypeVarPool, inferPolytypes: Boolean = true) exten
 
             case Some((_, unifiedType)) =>
               if (unifiedType.usedNames.size < operScheme.principalType.usedNames.size) {
-                // The number of free variables has decreased. The annotation by the user is to general.
+                // The number of free variables has decreased. The annotation by the user is too general.
                 val msg = s"$name's type annotation $userType is too general, inferred: $inferredType"
-                onTypeError(letEx.sourceRef, msg)
-                throw new UnwindException
+                onTypeWarn(letEx.sourceRef, msg)
               }
           }
         }
@@ -397,6 +396,10 @@ class EtcTypeChecker(varPool: TypeVarPool, inferPolytypes: Boolean = true) exten
 
   private def onTypeError(sourceRef: EtcRef, message: String): Unit = {
     listener.onTypeError(sourceRef, message)
+  }
+
+  private def onTypeWarn(sourceRef: EtcRef, message: String): Unit = {
+    listener.onTypeWarn(sourceRef, message)
   }
 
   // Pluralize the string "argument"

--- a/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/RecordingTypeCheckerListener.scala
+++ b/tla-typechecker/src/main/scala/at/forsyte/apalache/tla/typecheck/integration/RecordingTypeCheckerListener.scala
@@ -24,8 +24,11 @@ class RecordingTypeCheckerListener(sourceStore: SourceStore, changeListener: Cha
   }
 
   private val _errors: mutable.ListBuffer[(String, String)] = mutable.ListBuffer.empty
+  private val _warnings: mutable.ListBuffer[(String, String)] = mutable.ListBuffer.empty
 
   def getErrors(): List[(String, String)] = _errors.toList
+
+  def getWarnings(): List[(String, String)] = _warnings.toList
 
   override def onTypeFound(sourceRef: ExactRef, monotype: TlaType1): Unit = {
     uidToType += sourceRef.tlaId -> monotype
@@ -41,5 +44,17 @@ class RecordingTypeCheckerListener(sourceStore: SourceStore, changeListener: Cha
    */
   override def onTypeError(sourceRef: EtcRef, message: String): Unit = {
     _errors += (findLoc(sourceRef.tlaId) -> message)
+  }
+
+  /**
+   * This method is called when the type checker finds a type warning.
+   *
+   * @param sourceRef
+   *   a reference to the source expression; this one does not have to be exact
+   * @param message
+   *   the warning description
+   */
+  override def onTypeWarn(sourceRef: EtcRef, message: String): Unit = {
+    _warnings += (findLoc(sourceRef.tlaId) -> message)
   }
 }

--- a/tla-typechecker/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestEtcTypeChecker.scala
+++ b/tla-typechecker/src/test/scala/at/forsyte/apalache/tla/typecheck/etc/TestEtcTypeChecker.scala
@@ -924,7 +924,7 @@ class TestEtcTypeChecker extends AnyFunSuite with EasyMockSugar with BeforeAndAf
 
     val listener = mock[TypeCheckerListener]
     expecting {
-      listener.onTypeError(letIn.sourceRef.asInstanceOf[ExactRef],
+      listener.onTypeWarn(letIn.sourceRef.asInstanceOf[ExactRef],
           "F's type annotation ((a, b) => Bool) is too general, inferred: ((a, a) => Bool)")
       // consume all found types
       for (ex <- Seq(fBody, domX, domY, x, y, lambda, underLet, letIn, annotatedLetInF, bool, gAbs, letInG)) {


### PR DESCRIPTION
Apalache's type checker has a very useful feature that checks whether a generic type is precise, that is, it is using exactly as many variables as needed. Unfortunately, this does not play well with the Quint's typechecker, which still does not have this feature.

Now we produce a warning instead of a type error in this case. Otherwise, it is quite hard to deal with Quint specifications.

/cc: @bugarela 

- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
