### PR TITLE
Bump inbound GRPC messages to 1 GB

### DIFF
--- a/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
+++ b/shai/src/main/scala/at/forsyte/apalache/shai/v1/RpcServer.scala
@@ -37,11 +37,11 @@ class RpcServer(override val port: Int) extends ServerMain with LazyLogging {
   // This is needed even if the type below is omitted / inferred.
   import scala.language.existentials
 
-  // Set max inbound message size to 64MB
+  // Set max inbound message size to 1G
   // Fixes `io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size`:
   // https://github.com/apalache-mc/apalache/issues/2622
   override def builder: (x0) forSome { type x0 <: ServerBuilder[x0] } =
-    super.builder.maxInboundMessageSize(64 * 1024 * 1024)
+    super.builder.maxInboundMessageSize(1024 * 1024 * 1024)
 
   override def run(args: List[String]) = {
     myAppLogic.catchAll { t =>


### PR DESCRIPTION
Similar to #2623, bumping the GRPC limits to 1 GB, as we have hit the limit of 64 MB on a spec of reasonable size.

- [ ] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [ ] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
