### PR TITLE
fix function sets over empty domains/co-domains

### DIFF
--- a/.unreleased/bug-fixes/empty-function-sets.md
+++ b/.unreleased/bug-fixes/empty-function-sets.md
@@ -1,0 +1,2 @@
+Fix rewriting of function sets with empty domains or co-domains. This supersedes the incomplete preprocessing workaround
+#2481.

--- a/.unreleased/bug-fixes/empty-function-sets.md
+++ b/.unreleased/bug-fixes/empty-function-sets.md
@@ -1,2 +1,1 @@
-Fix rewriting of function sets with empty domains or co-domains. This supersedes the incomplete preprocessing workaround
-#2481.
+Fix rewriting of function sets with empty domains or co-domains. See #3478.

--- a/test/tla/EmptyFunctionSet.tla
+++ b/test/tla/EmptyFunctionSet.tla
@@ -1,0 +1,37 @@
+---- MODULE EmptyFunctionSet ----
+\* Regression test for: https://github.com/apalache-mc/apalache/issues/3476
+
+VARIABLES
+  \* @type: Bool;
+  empty,
+  \* @type: Set(Int -> Int);
+  fs,
+  \* @type: Set(Int -> Int);
+  baseline
+
+\* @type: () => Set(Int);
+Domain == IF empty THEN {} ELSE {1}
+
+\* @type: () => Set(Int);
+EmptyDomain == LET D == {} IN D
+
+\* @type: () => Set(Int);
+EmptyCodomain == LET C == {} IN C
+
+\* @type: () => (Int -> Int);
+EmptyFun == [x \in {} |-> 0]
+
+Init ==
+  /\ empty \in BOOLEAN
+  /\ fs = [Domain -> EmptyCodomain]
+  /\ baseline = [EmptyDomain -> EmptyCodomain]
+
+Next == UNCHANGED <<empty, fs, baseline>>
+
+Inv ==
+  /\ baseline = [EmptyDomain -> EmptyCodomain]
+  /\ fs = IF empty THEN {EmptyFun} ELSE {}
+  /\ [EmptyDomain -> {1}] = {EmptyFun}
+  /\ [{1} -> EmptyCodomain] = {}
+
+====

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2649,6 +2649,14 @@ $ apalache-mc check Bug1058.tla | sed 's/[IEW]@.*//'
 EXITCODE: OK
 ```
 
+### check EmptyFunctionSet.tla: empty function-set operands after rewriting
+
+```sh
+$ apalache-mc check --inv=Inv --length=0 --no-deadlock EmptyFunctionSet.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ### check Bug1136.tla reports no error: regression for #1136
 
 ```sh

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
@@ -5,11 +5,11 @@ import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, FinFunSetT, InfSetT, PowSetT}
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT, tlaU => tla}
+import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 
 /**
- * This rule constructs a cell for a function set [S -> T]. Nontrivial function sets stay unexpanded and point to S
- * and T. Function sets with a definitely empty operand are represented as an ordinary empty or singleton set.
+ * This rule constructs a cell for a function set [S -> T]. Nontrivial function sets stay unexpanded and point to S and
+ * T. Function sets with a definitely empty operand are represented as an ordinary empty or singleton set.
  *
  * @author
  *   Igor Konnov
@@ -21,6 +21,7 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
    * Set emptiness classification.
    */
   sealed private trait SetEmptiness {
+
     /**
      * The set is empty when the predicate holds true.
      */
@@ -55,7 +56,7 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = {
     state.ex match {
-      case funSetEx@OperEx(TlaSetOper.funSet, domEx, cdmEx) =>
+      case funSetEx @ OperEx(TlaSetOper.funSet, domEx, cdmEx) =>
         // switch to cell theory
         var nextState = rewriter.rewriteUntilDone(state.setRex(domEx))
         val dom = nextState.asCell
@@ -63,10 +64,10 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
         val cdm = nextState.asCell
 
         val funT = TlaType1.fromTypeTag(funSetEx.typeTag) match {
-          case SetT1(ft@FunT1(_, _)) => ft
-          case t =>
+          case SetT1(ft @ FunT1(_, _)) => ft
+          case t                       =>
             throw new TypingException(s"Function-set $funSetEx should have a set-of-functions type, found: $t",
-              funSetEx.ID)
+                funSetEx.ID)
         }
 
         (setEmptiness(nextState, dom), setEmptiness(nextState, cdm)) match {
@@ -74,11 +75,11 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
           case (StaticallyEmpty, _) =>
             makeSingletonWhen(nextState, funT, tla.bool(true))
 
-            // [S -> {}] contains the empty function exactly when S is empty.
+          // [S -> {}] contains the empty function exactly when S is empty.
           case (domEmptiness, StaticallyEmpty) =>
             makeSingletonWhen(nextState, funT, domEmptiness.predicate)
 
-            // the default case: rewrite to a special cell without expanding the set of functions
+          // the default case: rewrite to a special cell without expanding the set of functions
           case _ =>
             val arena = nextState.arena.appendCellOld(FinFunSetT(dom.cellType, cdm.cellType))
             val newCell = arena.topCell
@@ -108,7 +109,8 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
           StaticallyNonEmpty
         } else {
           // remove the elements that are known to be non-members statically
-          val potentialMembers = pointersAndPredicates.filterNot { case (_, pred) => simplifier.isFalseConst(pred) }.map(_._1.elem)
+          val potentialMembers =
+            pointersAndPredicates.filterNot { case (_, pred) => simplifier.isFalseConst(pred) }.map(_._1.elem)
           if (potentialMembers.isEmpty) {
             StaticallyEmpty
           } else {
@@ -119,11 +121,11 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
           }
         }
 
-        // Every powerset contains the empty set. The built-in infinite sets are non-empty too.
+      // Every powerset contains the empty set. The built-in infinite sets are non-empty too.
       case PowSetT(_) | InfSetT(_) =>
         StaticallyNonEmpty
 
-        // [S -> T] is empty exactly when S is non-empty and T is empty.
+      // [S -> T] is empty exactly when S is non-empty and T is empty.
       case FinFunSetT(_, _) =>
         val domEmptiness = setEmptiness(state, state.arena.getDom(set))
         val cdmEmptiness = setEmptiness(state, state.arena.getCdm(set))

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
@@ -1,18 +1,51 @@
 package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
-import at.forsyte.apalache.tla.bmcmt.types.FinFunSetT
-import at.forsyte.apalache.tla.lir.OperEx
+import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
+import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, FinFunSetT, InfSetT, PowSetT}
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
+import at.forsyte.apalache.tla.lir._
+import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT, tlaU => tla}
 
 /**
- * This rule constructs a cell for a function set [S -> T]. Since we are not expanding function sets by default, this
- * cell is just pointing to S as its domain and to T as its co-domain.
+ * This rule constructs a cell for a function set [S -> T]. Nontrivial function sets stay unexpanded and point to S
+ * and T. Function sets with a definitely empty operand are represented as an ordinary empty or singleton set.
  *
  * @author
  *   Igor Konnov
  */
 class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
+  private val simplifier = new ConstSimplifierForSmt
+
+  /**
+   * Set emptiness classification.
+   */
+  sealed private trait SetEmptiness {
+    /**
+     * The set is empty when the predicate holds true.
+     */
+    def predicate: BuilderT
+  }
+
+  /**
+   * A set is empty at translation time.
+   */
+  private case object StaticallyEmpty extends SetEmptiness {
+    override val predicate: BuilderT = tla.bool(true)
+  }
+
+  /**
+   * A set is non-empty at translation time.
+   */
+  private case object StaticallyNonEmpty extends SetEmptiness {
+    override val predicate: BuilderT = tla.bool(false)
+  }
+
+  /**
+   * A set may be empty when the predicate evaluates to true (in SMT).
+   */
+  private case class SymbolicallyEmptyWhen(predicate: BuilderT) extends SetEmptiness
+
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
       case OperEx(TlaSetOper.funSet, _, _) => true
@@ -22,21 +55,128 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = {
     state.ex match {
-      case OperEx(TlaSetOper.funSet, domEx, cdmEx) =>
+      case funSetEx@OperEx(TlaSetOper.funSet, domEx, cdmEx) =>
         // switch to cell theory
         var nextState = rewriter.rewriteUntilDone(state.setRex(domEx))
         val dom = nextState.asCell
         nextState = rewriter.rewriteUntilDone(nextState.setRex(cdmEx))
         val cdm = nextState.asCell
-        val arena = nextState.arena.appendCellOld(FinFunSetT(dom.cellType, cdm.cellType))
-        val newCell = arena.topCell
-        val newArena = arena
-          .setDom(newCell, dom)
-          .setCdm(newCell, cdm)
-        nextState.setArena(newArena).setRex(newCell.toNameEx)
+
+        val funT = TlaType1.fromTypeTag(funSetEx.typeTag) match {
+          case SetT1(ft@FunT1(_, _)) => ft
+          case t =>
+            throw new TypingException(s"Function-set $funSetEx should have a set-of-functions type, found: $t",
+              funSetEx.ID)
+        }
+
+        (setEmptiness(nextState, dom), setEmptiness(nextState, cdm)) match {
+          // There is exactly one function over the empty domain, independently of the co-domain.
+          case (StaticallyEmpty, _) =>
+            makeSingletonWhen(nextState, funT, tla.bool(true))
+
+            // [S -> {}] contains the empty function exactly when S is empty.
+          case (domEmptiness, StaticallyEmpty) =>
+            makeSingletonWhen(nextState, funT, domEmptiness.predicate)
+
+            // the default case: rewrite to a special cell without expanding the set of functions
+          case _ =>
+            val arena = nextState.arena.appendCellOld(FinFunSetT(dom.cellType, cdm.cellType))
+            val newCell = arena.topCell
+            val newArena = arena
+              .setDom(newCell, dom)
+              .setCdm(newCell, cdm)
+            nextState.setArena(newArena).setRex(newCell.toNameEx)
+        }
 
       case _ =>
         throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)
     }
+  }
+
+  /**
+   * Classify set emptiness from its rewritten arena representation. In particular, an ordinary finite set is empty when
+   * all of its potential membership pointers are false. The symbolic predicate is retained when emptiness depends on
+   * the current model.
+   */
+  private def setEmptiness(state: SymbState, set: ArenaCell): SetEmptiness = {
+    def simplify(ex: BuilderT): BuilderT = simplifier.applySimplifyShallowToBuilderEx(ex)
+
+    set.cellType match {
+      case CellTFrom(SetT1(_)) =>
+        val pointersAndPredicates = state.arena.getHasPtr(set).map(ptr => ptr -> simplify(ptr.toSmt))
+        if (pointersAndPredicates.exists { case (_, pred) => simplifier.isTrueConst(pred) }) {
+          StaticallyNonEmpty
+        } else {
+          // remove the elements that are known to be non-members statically
+          val potentialMembers = pointersAndPredicates.filterNot { case (_, pred) => simplifier.isFalseConst(pred) }.map(_._1.elem)
+          if (potentialMembers.isEmpty) {
+            StaticallyEmpty
+          } else {
+            // Pointer conditions are arena metadata and, in the Arrays encoding, may contain store expressions.
+            // Use actual set membership for the semantic emptiness predicate.
+            val noMember = potentialMembers.map(elem => tla.not(tla.selectInSet(elem.toBuilder, set.toBuilder)))
+            SymbolicallyEmptyWhen(simplify(tla.and(noMember: _*)))
+          }
+        }
+
+        // Every powerset contains the empty set. The built-in infinite sets are non-empty too.
+      case PowSetT(_) | InfSetT(_) =>
+        StaticallyNonEmpty
+
+        // [S -> T] is empty exactly when S is non-empty and T is empty.
+      case FinFunSetT(_, _) =>
+        val domEmptiness = setEmptiness(state, state.arena.getDom(set))
+        val cdmEmptiness = setEmptiness(state, state.arena.getCdm(set))
+        isFunSetEmpty(domEmptiness, cdmEmptiness)
+
+      case unexpected =>
+        throw new RewriterException(s"Expected a set cell, found: $unexpected", state.ex)
+    }
+  }
+
+  private def isFunSetEmpty(dom: SetEmptiness, cdm: SetEmptiness): SetEmptiness = {
+    def simplify(ex: BuilderT): BuilderT = simplifier.applySimplifyShallowToBuilderEx(ex)
+
+    (dom, cdm) match {
+      case (StaticallyEmpty, _) | (_, StaticallyNonEmpty) =>
+        StaticallyNonEmpty
+      case (StaticallyNonEmpty, StaticallyEmpty) =>
+        StaticallyEmpty
+      case (StaticallyNonEmpty, SymbolicallyEmptyWhen(cdmPred)) =>
+        SymbolicallyEmptyWhen(cdmPred)
+      case (SymbolicallyEmptyWhen(domPred), StaticallyEmpty) =>
+        SymbolicallyEmptyWhen(simplify(tla.not(domPred)))
+      case (SymbolicallyEmptyWhen(domPred), SymbolicallyEmptyWhen(cdmPred)) =>
+        SymbolicallyEmptyWhen(simplify(tla.and(tla.not(domPred), cdmPred)))
+    }
+  }
+
+  /** Construct either an empty set or a singleton containing the canonical empty function. */
+  private def makeSingletonWhen(state: SymbState, funT: FunT1, condition: BuilderT): SymbState = {
+    val simplifiedCondition = simplifier.applySimplifyShallowToBuilderEx(condition)
+    var nextState = state.updateArena(_.appendCell(SetT1(funT)))
+    val setCell = nextState.arena.topCell
+
+    if (simplifier.isFalseConst(simplifiedCondition)) {
+      return nextState.setRex(setCell.toBuilder)
+    }
+
+    val (arenaWithEmptyFun, emptyFun) = rewriter.defaultValueCache.getOrCreate(nextState.arena, funT)
+    nextState = nextState.setArena(arenaWithEmptyFun)
+
+    val ptr =
+      if (simplifier.isTrueConst(simplifiedCondition)) FixedElemPtr(emptyFun)
+      else SmtExprElemPtr(emptyFun, simplifiedCondition)
+    nextState = nextState.updateArena(_.appendHas(setCell, ptr))
+
+    val inSet = tla.storeInSet(emptyFun.toBuilder, setCell.toBuilder)
+    if (simplifier.isTrueConst(simplifiedCondition)) {
+      rewriter.solverContext.assertGroundExpr(inSet)
+    } else {
+      val notInSet = tla.storeNotInSet(emptyFun.toBuilder, setCell.toBuilder)
+      rewriter.solverContext.assertGroundExpr(tla.ite(simplifiedCondition, inSet, notInSet))
+    }
+
+    nextState.setRex(setCell.toBuilder)
   }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -10,6 +10,73 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   val i_to_B: TlaType1 = FunT1(IntT1, SetT1(BoolT1))
   val i_to_i_to_B: TlaType1 = FunT1(IntT1, FunT1(IntT1, SetT1(BoolT1)))
 
+  test("[{} -> {}] is a singleton containing the empty function") { rewriterType: SMTEncoding =>
+    val funSet = tla.funSet(tla.emptySet(IntT1), tla.emptySet(IntT1))
+    val state = new SymbState(funSet, arena, Binding())
+    val rewriter = create(rewriterType)
+    val nextState = rewriter.rewriteUntilDone(state)
+    val setCell = nextState.asCell
+
+    assert(setCell.cellType == CellTFrom(SetT1(FunT1(IntT1, IntT1))))
+    val Seq(FixedElemPtr(emptyFun)) = nextState.arena.getHasPtr(setCell)
+    assert(nextState.arena.getHas(nextState.arena.getDom(emptyFun)).isEmpty)
+    assert(nextState.arena.getHas(nextState.arena.getCdm(emptyFun)).isEmpty)
+    assertTlaExAndRestore(rewriter, nextState.setRex(tla.selectInSet(emptyFun.toBuilder, setCell.toBuilder)))
+  }
+
+  test("[{1} -> {}] is empty") { rewriterType: SMTEncoding =>
+    val funSet = tla.funSet(tla.enumSet(tla.int(1)), tla.emptySet(IntT1))
+    val state = new SymbState(funSet, arena, Binding())
+    val rewriter = create(rewriterType)
+    val nextState = rewriter.rewriteUntilDone(state)
+    val setCell = nextState.asCell
+
+    assert(setCell.cellType == CellTFrom(SetT1(FunT1(IntT1, IntT1))))
+    assert(nextState.arena.getHasPtr(setCell).isEmpty)
+  }
+
+  test("[S -> {}] conditionally contains the empty function when S is symbolically empty") {
+    rewriterType: SMTEncoding =>
+      val arenaWithGuard = arena.appendCell(BoolT1)
+      val guard = arenaWithGuard.topCell
+      val empty = tla.emptySet(IntT1)
+      val singleton = tla.enumSet(tla.int(1))
+      val domain = tla.ite(guard.toBuilder, empty, singleton)
+      val funSet = tla.funSet(domain, empty)
+      val state = new SymbState(funSet, arenaWithGuard, Binding())
+      val rewriter = create(rewriterType)
+      val nextState = rewriter.rewriteUntilDone(state)
+      val setCell = nextState.asCell
+
+      assert(setCell.cellType == CellTFrom(SetT1(FunT1(IntT1, IntT1))))
+      val Seq(ptr) = nextState.arena.getHasPtr(setCell)
+      val emptyFun = ptr.elem
+      val emptyFunInSet = tla.selectInSet(emptyFun.toBuilder, setCell.toBuilder)
+
+      rewriter.push()
+      rewriter.solverContext.assertGroundExpr(guard.toBuilder)
+      rewriter.solverContext.assertGroundExpr(emptyFunInSet)
+      assert(rewriter.solverContext.sat())
+      rewriter.pop()
+
+      rewriter.push()
+      rewriter.solverContext.assertGroundExpr(tla.not(guard.toBuilder))
+      rewriter.solverContext.assertGroundExpr(emptyFunInSet)
+      assertUnsatOrExplain()
+      rewriter.pop()
+  }
+
+  test("separately constructed [{} -> {}] values are equal") { rewriterType: SMTEncoding =>
+    val rewriter = create(rewriterType)
+    val funSet1 = tla.funSet(tla.emptySet(IntT1), tla.emptySet(IntT1))
+    val state1 = rewriter.rewriteUntilDone(new SymbState(funSet1, arena, Binding()))
+    val funSet2 = tla.funSet(tla.emptySet(IntT1), tla.emptySet(IntT1))
+    val state2 = rewriter.rewriteUntilDone(state1.setRex(funSet2))
+    val equality = tla.eql(state1.asCell.toBuilder, state2.asCell.toBuilder)
+
+    assertTlaExAndRestore(rewriter, state2.setRex(equality))
+  }
+
   test("""[{1, 2, 3} -> {FALSE, TRUE}]""") { rewriterType: SMTEncoding =>
     val domain = tla.enumSet(tla.int(1), tla.int(2), tla.int(3))
     val codomain = tla.enumSet(tla.bool(false), tla.bool(true))

--- a/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
+++ b/tla-pp/src/main/scala/at/forsyte/apalache/tla/pp/ConstSimplifierBase.scala
@@ -3,7 +3,7 @@ package at.forsyte.apalache.tla.pp
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values.{TlaBool, TlaInt, TlaStr}
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderT, BuilderUT}
+import at.forsyte.apalache.tla.types.{BuilderT, BuilderUT}
 
 import scala.collection.immutable.SortedSet
 
@@ -249,20 +249,6 @@ abstract class ConstSimplifierBase {
     // \A x \in S: FALSE <=> S = {}
     case OperEx(TlaBoolOper.forall, _, set, ValEx(TlaBool(false))) =>
       simplifyShallow(OperEx(TlaOper.eq, set, emptySet(set.typeTag))(boolTag))
-
-    // [{} -> X] <=> [{} -> {Gen(1)}]
-    case funSet @ OperEx(TlaSetOper.funSet, OperEx(TlaSetOper.enumSet), _) =>
-      val funSetT = TlaType1.fromTypeTag(funSet.typeTag)
-      funSetT match {
-        case SetT1(FunT1(domElemT, cdmElemT)) =>
-          val mockCdm = tla.gen(ValEx(TlaInt(1))(intTag), SetT1(cdmElemT))
-          tla.funSet(tla.emptySet(domElemT), mockCdm)
-        case t =>
-          throw new TypingException(s"Function-set $funSet should have a set-of-functions type, found: $t", funSet.ID)
-      }
-    // if A /= {}, then [ A -> {} ] <=> {}
-    case funSet @ OperEx(TlaSetOper.funSet, _, OperEx(TlaSetOper.enumSet)) =>
-      emptySet(funSet.typeTag)
 
     // Set simplifications that hold for an arbitrary set S, not only for set enumerations.
     // These complement the literal-only rules below.


### PR DESCRIPTION
Closes #3476. Fix the rewriting rule for sets of functions `[S -> T]` for the cases `S = {}` and `T = {}`, which demonstrate unusual behavior. This fix supersedes #2481, which was only sound for some cases.

Fixed with GPT-5.6-sol high/xhigh and then fixed by hand.

Postponing a similar issue #3477 with equality `[S -> T] = [U -> V]` for the case when one of the sets is empty.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md