### PR TITLE
Fix SetInRule

### DIFF
--- a/.unreleased/bug-fixes/3479-fold-singleton-membership.md
+++ b/.unreleased/bug-fixes/3479-fold-singleton-membership.md
@@ -1,0 +1,1 @@
+Fixed a crash when a fold's operator tests membership in a singleton set literal, see #3479.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PrimeRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/PrimeRule.scala
@@ -21,6 +21,9 @@ class PrimeRule extends RewritingRule {
 
   override def apply(state: SymbState): SymbState = {
     state.ex match {
+      case OperEx(TlaActionOper.prime, NameEx(name)) if ArenaCell.isValidName(name) =>
+        throw new RewriterException(s"Prime operator cannot be applied to arena cell $name", state.ex)
+
       case OperEx(TlaActionOper.prime, nEx @ NameEx(name)) =>
         state.setRex(tla.name(name + "'", TlaType1.fromTypeTag(nEx.typeTag)))
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/SetInRule.scala
@@ -34,7 +34,8 @@ class SetInRule(rewriter: SymbStateRewriter) extends RewritingRule {
     state.ex match {
       // a common pattern x \in {y} that is equivalent to x = y, e.g., the assignment solver creates it
       case OperEx(op, NameEx(name), OperEx(TlaSetOper.enumSet, rhs))
-          if op == TlaSetOper.in || op == ApalacheInternalOper.selectInSet =>
+          if (op == TlaSetOper.in || op == ApalacheInternalOper.selectInSet) &&
+            !ArenaCell.isValidName(name) =>
         val nextState = rewriter.rewriteUntilDone(state.setRex(rhs))
         val rhsCell = nextState.arena.findCellByNameEx(nextState.ex)
         val lhsCell = state.binding(name)

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterAction.scala
@@ -19,4 +19,13 @@ trait TestSymbStateRewriterAction extends RewriterBase {
         fail("Expected x to be renamed to x'")
     }
   }
+
+  test("prime rejects arena cells") { rewriterType: SMTEncoding =>
+    arena = arena.appendCell(IntT1)
+    val cell = arena.topCell
+    val state = new SymbState(tla.prime(cell.toBuilder), arena, Binding())
+
+    val error = intercept[RewriterException](create(rewriterType).rewriteOnce(state))
+    assert(error.getMessage.contains(s"Prime operator cannot be applied to arena cell $cell"))
+  }
 }

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterSet.scala
@@ -279,6 +279,18 @@ trait TestSymbStateRewriterSet extends RewriterBase {
     }
   }
 
+  test("""an arena cell \in {1}""") { rewriterType: SMTEncoding =>
+    // Regression for #3479: arena-cell names are not stored in Binding, so they must bypass
+    // the singleton-set optimization that resolves the left-hand side through Binding.
+    arena = arena.appendCell(IntT1)
+    val cell = arena.topCell
+    val membership = tla.in(cell.toBuilder, tla.enumSet(tla.int(1)))
+    val expected = tla.eql(cell.toBuilder, tla.int(1))
+    val state = new SymbState(tla.eql(membership, expected), arena, Binding())
+
+    assertTlaExAndRestore(create(rewriterType), state)
+  }
+
   test("""~(Bool \in {TRUE, TRUE})""") { rewriterType: SMTEncoding =>
     arena = arena.appendCell(BoolT1)
     val cell = arena.topCell


### PR DESCRIPTION
Closes #3479. When `SetInRule` was called inside a fold, it was passing an arena cell as a name. This failed in the optimization case. The fix is to guard this optimization case with a check that the name is not a cell. Also, adding a similar test to `PrimeRule`.

Fixed with GPT-5.6-sol medium.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md