### PR TITLE
fix: PrettyWriter parenthesizes LET

### DIFF
--- a/.unreleased/bug-fixes/pretty-writer-synthesized-let.md
+++ b/.unreleased/bug-fixes/pretty-writer-synthesized-let.md
@@ -1,0 +1,2 @@
+Fixed PrettyWriter changing expression scope when hoisting lambda argument declarations into LET-IN expressions,
+see [model-checker-hardening#88](https://github.com/tlaplus/model-checker-hardening/issues/88).

--- a/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
+++ b/tla-io/src/main/scala/at/forsyte/apalache/io/lir/PrettyWriter.scala
@@ -8,9 +8,8 @@ import at.forsyte.apalache.tla.lir.oper._
 import at.forsyte.apalache.tla.lir.values._
 import org.bitbucket.inkytonik.kiama.output.PrettyPrinter
 
-import java.io.{File, FileWriter, PrintWriter}
+import java.io.{File, FileWriter, PrintWriter, StringWriter}
 import scala.collection.immutable.{HashMap, HashSet}
-import java.io.StringWriter
 
 /**
  * <p>A pretty printer to a file that formats a TLA+ expression to a given text width (normally, 80 characters). As
@@ -493,7 +492,7 @@ class PrettyWriter(
           } else if (decls.isEmpty) {
             group(parseableName(name) <> parens(commaSeparated))
           } else {
-            group(ssep(decls, line) <> line <> parseableName(name) <> parens(commaSeparated))
+            letToDocInParens(decls, parseableName(name) <> parens(commaSeparated))
           }
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
@@ -520,7 +519,7 @@ class PrettyWriter(
           } else if (decls.isEmpty) {
             group(unqualifiedName <> parens(commaSeparated))
           } else {
-            group(ssep(decls, line) <> line <> unqualifiedName <> parens(commaSeparated))
+            letToDocInParens(decls, unqualifiedName <> parens(commaSeparated))
           }
 
         wrapWithParen(parentPrecedence, op.precedence, doc)
@@ -548,6 +547,12 @@ class PrettyWriter(
 
       case expr => throw new PrettyPrinterError(s"PrettyPrinter failed toDoc conversion on expression ${expr}")
     }
+  }
+
+  private def letToDocInParens(decls: List[Doc], application: Doc): Doc = {
+    // Hoisting declarations turns an application into a LET whose scope extends to the right.
+    // Always delimit it, even in contexts such as CASE OTHER that pass parent precedence (0, 0).
+    parens(group(ssep(decls, line) <> line <> application))
   }
 
   /**

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -969,12 +969,12 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
         else OperEx(ApalacheOper.foldSeq, lambda, bool(false), tuple())
       val expectedCall = s"(LET Lambda3(p, q) == p IN $opName(Lambda3, FALSE, <<>>))"
       val cases: Seq[(TlaEx, String)] = Seq(
-        (call, expectedCall),
-        (and(eql(name("var0"), call), eql(name("step"), int(0))), s"var0 = $expectedCall /\\ step = 0"),
-        (and(call, bool(true)), s"$expectedCall /\\ TRUE"),
-        (impl(call, bool(true)), s"$expectedCall => TRUE"),
-        (in(call, name("S")), s"$expectedCall \\in S"),
-        (caseOther(call, bool(true), bool(false)), s"CASE TRUE -> FALSE [] OTHER -> $expectedCall"),
+          (call, expectedCall),
+          (and(eql(name("var0"), call), eql(name("step"), int(0))), s"var0 = $expectedCall /\\ step = 0"),
+          (and(call, bool(true)), s"$expectedCall /\\ TRUE"),
+          (impl(call, bool(true)), s"$expectedCall => TRUE"),
+          (in(call, name("S")), s"$expectedCall \\in S"),
+          (caseOther(call, bool(true), bool(false)), s"CASE TRUE -> FALSE [] OTHER -> $expectedCall"),
       )
       cases.foreach { case (expr, expected) =>
         val buffer = new StringWriter()

--- a/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
+++ b/tla-io/src/test/scala/at/forsyte/apalache/io/lir/TestPrettyWriter.scala
@@ -5,7 +5,7 @@ import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.convenience.tla
 import at.forsyte.apalache.tla.lir.convenience.tla._
-import at.forsyte.apalache.tla.lir.oper.{TlaArithOper, TlaFunOper, TlaOper}
+import at.forsyte.apalache.tla.lir.oper.{ApalacheOper, TlaArithOper, TlaFunOper, TlaOper}
 import at.forsyte.apalache.tla.lir.values.TlaInt
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
@@ -949,10 +949,54 @@ class TestPrettyWriter extends AnyFunSuite with BeforeAndAfterEach {
     printWriter.flush()
     // LET declaration needs to be printed before the application
     val expected =
-      """LET A(param1, param2) == param1 + param2
+      """(LET A(param1, param2) ==
+        |  param1 + param2
         |IN
-        |Foo((A(1, 2)))""".stripMargin
+        |Foo((A(1, 2))))""".stripMargin
     assert(expected == stringWriter.toString)
+  }
+
+  for {
+    named <- Seq(false, true)
+    width <- Seq(20, 1000)
+  } {
+    test(s"synthesized LET is delimited (named=$named, width=$width)") {
+      val decl = TlaOperDecl("Lambda3", List(OperParam("p"), OperParam("q")), name("p"))
+      val lambda = letIn(name("Lambda3"), decl)
+      val opName = if (named) "Fold" else "ApaFoldSeqLeft"
+      val call: TlaEx =
+        if (named) appOp(name(opName), lambda, bool(false), tuple())
+        else OperEx(ApalacheOper.foldSeq, lambda, bool(false), tuple())
+      val expectedCall = s"(LET Lambda3(p, q) == p IN $opName(Lambda3, FALSE, <<>>))"
+      val cases: Seq[(TlaEx, String)] = Seq(
+        (call, expectedCall),
+        (and(eql(name("var0"), call), eql(name("step"), int(0))), s"var0 = $expectedCall /\\ step = 0"),
+        (and(call, bool(true)), s"$expectedCall /\\ TRUE"),
+        (impl(call, bool(true)), s"$expectedCall => TRUE"),
+        (in(call, name("S")), s"$expectedCall \\in S"),
+        (caseOther(call, bool(true), bool(false)), s"CASE TRUE -> FALSE [] OTHER -> $expectedCall"),
+      )
+      cases.foreach { case (expr, expected) =>
+        val buffer = new StringWriter()
+        val output = new PrintWriter(buffer)
+        new PrettyWriter(output, TextLayout().copy(textWidth = width)).write(expr)
+        output.flush()
+        val printed = buffer.toString
+        assert(printed.replaceAll("\\s+", " ") == expected)
+        assert(printed.contains("\n") == (width == 20))
+      }
+    }
+  }
+
+  test("synthesized LET parentheses enclose all extracted declarations") {
+    val first = TlaOperDecl("Lambda3", List(OperParam("p")), name("p"))
+    val second = TlaOperDecl("Lambda4", List(OperParam("q")), name("q"))
+    val expr = appOp(name("Combine"), letIn(name("Lambda3"), first), letIn(name("Lambda4"), second))
+    val writer = new PrettyWriter(printWriter, layout40)
+    writer.write(expr)
+    printWriter.flush()
+    assert(stringWriter.toString.replaceAll("\\s+", " ") ==
+      "(LET Lambda3(p) == p IN LET Lambda4(q) == q IN Combine(Lambda3, Lambda4))")
   }
 
   test("a LAMBDA as LET-IN") {

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -3,7 +3,8 @@ package at.forsyte.apalache.tla.imp
 import at.forsyte.apalache.io.lir.{PrettyWriter, TextLayout}
 import at.forsyte.apalache.tla.lir.UntypedPredefs._
 import at.forsyte.apalache.tla.lir.convenience.tla.{not => tlaNot, _}
-import at.forsyte.apalache.tla.lir.{TlaEx, TlaOperDecl}
+import at.forsyte.apalache.tla.lir.oper.ApalacheOper
+import at.forsyte.apalache.tla.lir.{OperEx, OperParam, TlaEx, TlaOperDecl}
 
 import java.io.{PrintWriter, StringWriter}
 import scala.io.Source
@@ -15,10 +16,10 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
       expectedText: String,
       expectedParsed: TlaEx)
 
-  private def write(ex: TlaEx): String = {
+  private def write(ex: TlaEx, width: Int = 80): String = {
     val stringWriter = new StringWriter()
     val printWriter = new PrintWriter(stringWriter)
-    new PrettyWriter(printWriter, TextLayout().copy(textWidth = 80)).write(ex)
+    new PrettyWriter(printWriter, TextLayout().copy(textWidth = width)).write(ex)
     printWriter.flush()
     stringWriter.toString
   }
@@ -40,14 +41,62 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
              |Test == $printed
              |================================
              |""".stripMargin
-        val (rootName, modules) = sanyImporter.loadFromSource(Source.fromString(source))
-        val parsed = modules(rootName).declarations
-          .collectFirst {
-            case decl: TlaOperDecl if decl.name == "Test" => decl.body
-          }
-          .getOrElse(fail("SANY did not import the Test declaration"))
+        assert(parseTestBody(source) == testCase.expectedParsed)
+      }
+    }
+  }
 
-        assert(parsed == testCase.expectedParsed)
+  private def parseTestBody(source: String): TlaEx = {
+    val (rootName, modules) = sanyImporter.loadFromSource(Source.fromString(source))
+    modules(rootName).declarations
+      .collectFirst {
+        case decl: TlaOperDecl if decl.name == "Test" => decl.body
+      }
+      .getOrElse(fail("SANY did not import the Test declaration"))
+  }
+
+  for {
+    named <- Seq(false, true)
+    multipleDecls <- Seq(false, true)
+    width <- Seq(20, 1000)
+  } {
+    test(s"synthesized LET preserves scope through SANY (named=$named, multiple=$multipleDecls, width=$width)") {
+      val lambdaDecl = TlaOperDecl("Lambda3", List(OperParam("p"), OperParam("q")), name("p"))
+      val seedDecl = TlaOperDecl("Seed", List.empty, bool(false))
+      val lambda = letIn(name("Lambda3"), lambdaDecl)
+      val seed = if (multipleDecls) letIn(appDecl(seedDecl), seedDecl) else bool(false)
+
+      def call(operatorArg: TlaEx, seedArg: TlaEx): TlaEx =
+        if (named) appOp(name("Fold"), operatorArg, seedArg, tuple())
+        else OperEx(ApalacheOper.foldSeq, operatorArg, seedArg, tuple())
+
+      val original = call(lambda, seed)
+      // The printer hoists argument-local definitions. SANY should recover that hoisted tree,
+      // not the original argument-local LETs, and must not move any surrounding operands into it.
+      val expectedBody = call(name("Lambda3"), if (multipleDecls) appDecl(seedDecl) else bool(false))
+      val expected = letIn(if (multipleDecls) letIn(expectedBody, seedDecl) else expectedBody, lambdaDecl)
+      val contexts: Seq[(String, TlaEx => TlaEx)] = Seq(
+        ("top level", ex => ex),
+        ("issue 88", ex => and(eql(name("var0"), ex), eql(name("step"), int(0)))),
+        ("conjunction", ex => and(ex, eql(name("step"), int(0)))),
+        ("implication", ex => impl(eql(name("var0"), ex), eql(name("step"), int(0)))),
+        ("membership", ex => and(in(ex, enumSet(bool(false))), eql(name("step"), int(0)))),
+        ("CASE OTHER", ex => and(caseOther(ex, bool(true), bool(false)), eql(name("step"), int(0)))),
+        ("IF branch", ex => and(ite(bool(true), ex, bool(false)), eql(name("step"), int(0)))),
+      )
+      contexts.zipWithIndex.foreach { case ((label, context), index) =>
+        val printed = write(context(original), width)
+        val source =
+          s"""---- MODULE SynthesizedLet$index ----
+             |EXTENDS Integers, Sequences, Apalache
+             |VARIABLES var0, step
+             |Fold(Op(_, _), initial, seq) == ApaFoldSeqLeft(Op, initial, seq)
+             |Test == $printed
+             |================================
+             |""".stripMargin
+        withClue(s"$label: $printed\n") {
+          assert(parseTestBody(source) == context(expected))
+        }
       }
     }
   }

--- a/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
+++ b/tla-parser/src/test/scala/at/forsyte/apalache/tla/imp/TestPrettyWriterPrecedence.scala
@@ -76,13 +76,13 @@ class TestPrettyWriterPrecedence extends SanyImporterTestBase {
       val expectedBody = call(name("Lambda3"), if (multipleDecls) appDecl(seedDecl) else bool(false))
       val expected = letIn(if (multipleDecls) letIn(expectedBody, seedDecl) else expectedBody, lambdaDecl)
       val contexts: Seq[(String, TlaEx => TlaEx)] = Seq(
-        ("top level", ex => ex),
-        ("issue 88", ex => and(eql(name("var0"), ex), eql(name("step"), int(0)))),
-        ("conjunction", ex => and(ex, eql(name("step"), int(0)))),
-        ("implication", ex => impl(eql(name("var0"), ex), eql(name("step"), int(0)))),
-        ("membership", ex => and(in(ex, enumSet(bool(false))), eql(name("step"), int(0)))),
-        ("CASE OTHER", ex => and(caseOther(ex, bool(true), bool(false)), eql(name("step"), int(0)))),
-        ("IF branch", ex => and(ite(bool(true), ex, bool(false)), eql(name("step"), int(0)))),
+          ("top level", ex => ex),
+          ("issue 88", ex => and(eql(name("var0"), ex), eql(name("step"), int(0)))),
+          ("conjunction", ex => and(ex, eql(name("step"), int(0)))),
+          ("implication", ex => impl(eql(name("var0"), ex), eql(name("step"), int(0)))),
+          ("membership", ex => and(in(ex, enumSet(bool(false))), eql(name("step"), int(0)))),
+          ("CASE OTHER", ex => and(caseOther(ex, bool(true), bool(false)), eql(name("step"), int(0)))),
+          ("IF branch", ex => and(ite(bool(true), ex, bool(false)), eql(name("step"), int(0)))),
       )
       contexts.zipWithIndex.foreach { case ((label, context), index) =>
         val printed = write(context(original), width)


### PR DESCRIPTION
Addresses https://github.com/tlaplus/model-checker-hardening/issues/88. In some cases, `PrettyWriter` outputs `LET-IN` that is parsed by SANY differently. See [apalache-printer-008.md](https://github.com/tlaplus/model-checker-hardening/blob/main/findings/apalache-printer/apalache-printer-008.md) for an example. The solution is to parenthesize LET.

Done with gpt-6-astra.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md