### PR TITLE
Fix lazy equality on function sets

### DIFF
--- a/.unreleased/bug-fixes/3477-function-set-equality.md
+++ b/.unreleased/bug-fixes/3477-function-set-equality.md
@@ -1,0 +1,1 @@
+Fix equality of function sets with symbolically empty domains or co-domains. See #3477.

--- a/test/tla/FunctionSetEquality3477.tla
+++ b/test/tla/FunctionSetEquality3477.tla
@@ -1,0 +1,50 @@
+---- MODULE FunctionSetEquality3477 ----
+\* Regression for https://github.com/apalache-mc/apalache/issues/3477.
+\* All operand emptiness combinations are explored symbolically.
+
+VARIABLES
+  \* @type: Bool;
+  d1,
+  \* @type: Bool;
+  d2,
+  \* @type: Bool;
+  c1,
+  \* @type: Bool;
+  c2
+
+S1 == IF d1 THEN {} ELSE {1}
+S2 == IF d2 THEN {} ELSE {2}
+T1 == IF c1 THEN {} ELSE {3}
+T2 == IF c2 THEN {} ELSE {4}
+
+\* @type: () => Set(Int);
+Empty == {}
+
+\* @type: () => (Int -> Int);
+EmptyFun == [x \in {} |-> 0]
+
+Init ==
+  /\ d1 \in BOOLEAN
+  /\ d2 \in BOOLEAN
+  /\ c1 \in BOOLEAN
+  /\ c2 \in BOOLEAN
+
+Next == UNCHANGED <<d1, d2, c1, c2>>
+
+Inv ==
+  \* Disjoint nonempty domains and codomains: only the two degenerate cases can agree.
+  /\ (([S1 -> T1] = [S2 -> T2]) <=>
+        ((d1 /\ d2) \/ (~d1 /\ ~d2 /\ c1 /\ c2)))
+  \* A shared domain does not make distinct nonempty codomains equal.
+  /\ (([S1 -> T1] = [S1 -> T2]) <=> (d1 \/ (c1 /\ c2)))
+  \* A shared nonempty codomain does not make distinct nonempty domains equal.
+  /\ (([S1 -> {3}] = [S2 -> {3}]) <=> (d1 /\ d2))
+  \* A lazy set can be equal to an ordinary empty set or the empty-function singleton.
+  /\ (([S1 -> T1] = [S2 -> Empty]) <=>
+        ((d1 /\ d2) \/ (~d1 /\ ~d2 /\ c1)))
+  /\ (([S1 -> T1] = {EmptyFun}) <=> d1)
+  /\ (([S1 -> T1] = {}) <=> (~d1 /\ c1))
+  \* Nested function sets: their emptiness must also be interpreted semantically.
+  /\ (([{0} -> [{1} -> T1]] = [{10} -> [{2} -> T1]]) <=> c1)
+
+====

--- a/test/tla/cli-integration-tests.md
+++ b/test/tla/cli-integration-tests.md
@@ -2657,6 +2657,14 @@ $ apalache-mc check --inv=Inv --length=0 --no-deadlock EmptyFunctionSet.tla | se
 EXITCODE: OK
 ```
 
+### check FunctionSetEquality3477.tla: equality with symbolically empty operands
+
+```sh
+$ apalache-mc check --inv=Inv --length=0 --no-deadlock FunctionSetEquality3477.tla | sed 's/[IEW]@.*//'
+...
+EXITCODE: OK
+```
+
 ### check Bug1136.tla reports no error: regression for #1136
 
 ```sh

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -9,7 +9,7 @@ import at.forsyte.apalache.tla.bmcmt.rules.support.{ProtoSeqOps, RecordAndVarian
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.typecomp._
-import at.forsyte.apalache.tla.types.{BuilderT, tla}
+import at.forsyte.apalache.tla.types.{tla, BuilderT}
 import scalaz.unused
 
 import scala.collection.immutable.SortedMap
@@ -303,7 +303,7 @@ class LazyEquality(rewriter: SymbStateRewriter)
     }
     if (funSet.cellType.toTlaType1 != set.cellType.toTlaType1 || !onlyEmptyFunctions) {
       throw new RewriterException("Equality between a function set and an enumerated set of nonempty-domain " +
-        "functions is not supported", state.ex)
+            "functions is not supported", state.ex)
     }
 
     val setEmpty = tla.unchecked(SetEmptiness(state, set).predicate)
@@ -315,13 +315,13 @@ class LazyEquality(rewriter: SymbStateRewriter)
 
   /** Mixed representations have different uninterpreted sorts, but share their array sort in the Arrays encoding. */
   private def cacheFunSetEqPredicate(
-                                      state: SymbState,
-                                      left: ArenaCell,
-                                      right: ArenaCell,
-                                      predicate: BuilderT): SymbState = {
+      state: SymbState,
+      left: ArenaCell,
+      right: ArenaCell,
+      predicate: BuilderT): SymbState = {
     val simplified = simplifier.applySimplifyShallowToBuilderEx(predicate)
     if (
-      left.cellType.signature == right.cellType.signature ||
+        left.cellType.signature == right.cellType.signature ||
         rewriter.solverContext.config.smtEncoding == SMTEncoding.Arrays
     ) {
       // Arrays also need this constraint when these values are used as keys in enclosing sets.

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -284,9 +284,12 @@ class LazyEquality(rewriter: SymbStateRewriter)
     val c2 = tla.unchecked(SetEmptiness(nextState, cdm2).predicate)
 
     // #3477: both singleton empty-function sets, both empty sets, or matching operands.
-    // See test/tla/FunctionSetEqualityProofs.tla for the characterization proved in TLAPS.
-    val predicate = tla
-      .or(tla.and(d1, d2), tla.and(tla.not(d1), tla.not(d2), c1, c2), tla.and(safeEq(dom1, dom2), safeEq(cdm1, cdm2)))
+    // See https://gist.github.com/konnov/cc33215f5026e85abe8c75f96b1e5d02 for the characterization proved in TLAPS.
+    val predicate = tla.or(
+        tla.and(d1, d2),
+        tla.and(tla.not(d1), tla.not(d2), c1, c2),
+        tla.and(safeEq(dom1, dom2), safeEq(cdm1, cdm2)),
+    )
     cacheFunSetEqPredicate(nextState, left, right, predicate).setRex(state.ex)
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -5,11 +5,11 @@ import at.forsyte.apalache.tla.bmcmt.caches.{EqCache, EqCacheSnapshot}
 import at.forsyte.apalache.tla.bmcmt.implicitConversions._
 import at.forsyte.apalache.tla.bmcmt.rewriter.{ConstSimplifierForSmt, Recoverable}
 import at.forsyte.apalache.tla.bmcmt.rules.support.SupportOps._
-import at.forsyte.apalache.tla.bmcmt.rules.support.{ProtoSeqOps, RecordAndVariantOps}
+import at.forsyte.apalache.tla.bmcmt.rules.support.{ProtoSeqOps, RecordAndVariantOps, SetEmptiness}
 import at.forsyte.apalache.tla.bmcmt.types._
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.typecomp._
-import at.forsyte.apalache.tla.types.{tla, BuilderT}
+import at.forsyte.apalache.tla.types.{BuilderT, tla}
 import scalaz.unused
 
 import scala.collection.immutable.SortedMap
@@ -168,6 +168,12 @@ class LazyEquality(rewriter: SymbStateRewriter)
           case (FinFunSetT(_, _), FinFunSetT(_, _)) =>
             mkFunSetEq(state, left, right)
 
+          case (FinFunSetT(_, _), CellTFrom(SetT1(FunT1(_, _)))) =>
+            mkFunSetEmptyEq(state, left, right)
+
+          case (CellTFrom(SetT1(FunT1(_, _))), FinFunSetT(_, _)) =>
+            mkFunSetEmptyEq(state, right, left)
+
           case (lt, rt) =>
             throw new CheckerException(s"Unexpected equality test over types $lt and $rt", state.ex)
         }
@@ -270,15 +276,65 @@ class LazyEquality(rewriter: SymbStateRewriter)
     val cdm1 = state.arena.getCdm(left)
     val dom2 = state.arena.getDom(right)
     val cdm2 = state.arena.getCdm(right)
-    var nextState = mkSetEq(state, dom1, dom2)
-    nextState = mkSetEq(nextState, cdm1, cdm2)
-    val eq = tla.equiv(tla.eql(left.toBuilder, right.toBuilder),
-        tla.and(tla.eql(dom1.toBuilder, dom2.toBuilder), tla.eql(cdm1.toBuilder, cdm2.toBuilder)))
-    rewriter.solverContext.assertGroundExpr(eq)
-    eqCache.put(left, right, EqCache.EqEntry())
+    var nextState = cacheOneEqConstraint(state, dom1, dom2)
+    nextState = cacheOneEqConstraint(nextState, cdm1, cdm2)
+    val d1 = tla.unchecked(SetEmptiness(nextState, dom1).predicate)
+    val d2 = tla.unchecked(SetEmptiness(nextState, dom2).predicate)
+    val c1 = tla.unchecked(SetEmptiness(nextState, cdm1).predicate)
+    val c2 = tla.unchecked(SetEmptiness(nextState, cdm2).predicate)
 
-    // recover the original expression and theory
-    nextState.setRex(state.ex)
+    // #3477: both singleton empty-function sets, both empty sets, or matching operands.
+    // See test/tla/FunctionSetEqualityProofs.tla for the characterization proved in TLAPS.
+    val predicate = tla
+      .or(tla.and(d1, d2), tla.and(tla.not(d1), tla.not(d2), c1, c2), tla.and(safeEq(dom1, dom2), safeEq(cdm1, cdm2)))
+    cacheFunSetEqPredicate(nextState, left, right, predicate).setRex(state.ex)
+  }
+
+  /**
+   * Compare a lazy function set with an ordinary empty set or a (possibly conditional) singleton containing the empty
+   * function. FunSetCtorRule produces these ordinary sets when an operand is definitely empty. General comparison to
+   * enumerated sets of nonempty-domain functions remains unsupported: it would require a different coverage encoding.
+   */
+  private def mkFunSetEmptyEq(state: SymbState, funSet: ArenaCell, set: ArenaCell): SymbState = {
+    val onlyEmptyFunctions = state.arena.getHas(set).forall { fun =>
+      // OOPSLA19 functions need not have a domain edge; their relation is empty iff their domain is empty.
+      val support = if (state.arena.hasDom(fun)) state.arena.getDom(fun) else state.arena.getCdm(fun)
+      SetEmptiness(state, support) == SetEmptiness.StaticallyEmpty
+    }
+    if (funSet.cellType.toTlaType1 != set.cellType.toTlaType1 || !onlyEmptyFunctions) {
+      throw new RewriterException("Equality between a function set and an enumerated set of nonempty-domain " +
+        "functions is not supported", state.ex)
+    }
+
+    val setEmpty = tla.unchecked(SetEmptiness(state, set).predicate)
+    val domEmpty = tla.unchecked(SetEmptiness(state, state.arena.getDom(funSet)).predicate)
+    val funSetEmpty = tla.unchecked(SetEmptiness(state, funSet).predicate)
+    val predicate = tla.or(tla.and(tla.not(setEmpty), domEmpty), tla.and(setEmpty, funSetEmpty))
+    cacheFunSetEqPredicate(state, funSet, set, predicate)
+  }
+
+  /** Mixed representations have different uninterpreted sorts, but share their array sort in the Arrays encoding. */
+  private def cacheFunSetEqPredicate(
+                                      state: SymbState,
+                                      left: ArenaCell,
+                                      right: ArenaCell,
+                                      predicate: BuilderT): SymbState = {
+    val simplified = simplifier.applySimplifyShallowToBuilderEx(predicate)
+    if (
+      left.cellType.signature == right.cellType.signature ||
+        rewriter.solverContext.config.smtEncoding == SMTEncoding.Arrays
+    ) {
+      // Arrays also need this constraint when these values are used as keys in enclosing sets.
+      rewriter.solverContext.assertGroundExpr(tla.equiv(tla.eql(left.toBuilder, right.toBuilder), simplified))
+      eqCache.put(left, right, EqCache.EqEntry())
+      state
+    } else {
+      val nextState = state.updateArena(_.appendCell(BoolT1))
+      val pred = nextState.arena.topCell
+      rewriter.solverContext.assertGroundExpr(tla.equiv(pred.toBuilder, simplified))
+      eqCache.put(left, right, EqCache.ExprEntry(pred.toNameEx))
+      nextState
+    }
   }
 
   /**

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/LazyEquality.scala
@@ -299,7 +299,9 @@ class LazyEquality(rewriter: SymbStateRewriter)
    * enumerated sets of nonempty-domain functions remains unsupported: it would require a different coverage encoding.
    */
   private def mkFunSetEmptyEq(state: SymbState, funSet: ArenaCell, set: ArenaCell): SymbState = {
+    // All empty functions are equal, so this guarantees at most one distinct member, even with multiple arena edges.
     val onlyEmptyFunctions = state.arena.getHas(set).forall { fun =>
+      // For function cells, cdm is the graph relation, not the target set as it is for function-set cells.
       // OOPSLA19 functions need not have a domain edge; their relation is empty iff their domain is empty.
       val support = if (state.arena.hasDom(fun)) state.arena.getDom(fun) else state.arena.getCdm(fun)
       SetEmptiness(state, support) == SetEmptiness.StaticallyEmpty

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
@@ -2,10 +2,12 @@ package at.forsyte.apalache.tla.bmcmt.rules
 
 import at.forsyte.apalache.tla.bmcmt._
 import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
-import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, FinFunSetT, InfSetT, PowSetT}
-import at.forsyte.apalache.tla.lir.oper.TlaSetOper
+import at.forsyte.apalache.tla.bmcmt.rules.support.SetEmptiness
+import at.forsyte.apalache.tla.bmcmt.rules.support.SetEmptiness.StaticallyEmpty
+import at.forsyte.apalache.tla.bmcmt.types.FinFunSetT
 import at.forsyte.apalache.tla.lir._
-import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
+import at.forsyte.apalache.tla.lir.oper.TlaSetOper
+import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT, tlaU => tla}
 
 /**
  * This rule constructs a cell for a function set [S -> T]. Nontrivial function sets stay unexpanded and point to S and
@@ -16,36 +18,6 @@ import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
  */
 class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
   private val simplifier = new ConstSimplifierForSmt
-
-  /**
-   * Set emptiness classification.
-   */
-  sealed private trait SetEmptiness {
-
-    /**
-     * The set is empty when the predicate holds true.
-     */
-    def predicate: BuilderT
-  }
-
-  /**
-   * A set is empty at translation time.
-   */
-  private case object StaticallyEmpty extends SetEmptiness {
-    override val predicate: BuilderT = tla.bool(true)
-  }
-
-  /**
-   * A set is non-empty at translation time.
-   */
-  private case object StaticallyNonEmpty extends SetEmptiness {
-    override val predicate: BuilderT = tla.bool(false)
-  }
-
-  /**
-   * A set may be empty when the predicate evaluates to true (in SMT).
-   */
-  private case class SymbolicallyEmptyWhen(predicate: BuilderT) extends SetEmptiness
 
   override def isApplicable(symbState: SymbState): Boolean = {
     symbState.ex match {
@@ -70,7 +42,7 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
                 funSetEx.ID)
         }
 
-        (setEmptiness(nextState, dom), setEmptiness(nextState, cdm)) match {
+        (SetEmptiness(nextState, dom), SetEmptiness(nextState, cdm)) match {
           // There is exactly one function over the empty domain, independently of the co-domain.
           case (StaticallyEmpty, _) =>
             makeSingletonWhen(nextState, funT, tla.bool(true))
@@ -81,7 +53,8 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
           // the default case: rewrite to a special cell without expanding the set of functions
           case _ =>
-            val arena = nextState.arena.appendCellOld(FinFunSetT(dom.cellType, cdm.cellType))
+            // This is an unexpanded set, not an empty array. LazyEquality constrains its equality semantics.
+            val arena = nextState.arena.appendCellOld(FinFunSetT(dom.cellType, cdm.cellType), isUnconstrained = true)
             val newCell = arena.topCell
             val newArena = arena
               .setDom(newCell, dom)
@@ -91,65 +64,6 @@ class FunSetCtorRule(rewriter: SymbStateRewriter) extends RewritingRule {
 
       case _ =>
         throw new RewriterException("%s is not applicable".format(getClass.getSimpleName), state.ex)
-    }
-  }
-
-  /**
-   * Classify set emptiness from its rewritten arena representation. In particular, an ordinary finite set is empty when
-   * all of its potential membership pointers are false. The symbolic predicate is retained when emptiness depends on
-   * the current model.
-   */
-  private def setEmptiness(state: SymbState, set: ArenaCell): SetEmptiness = {
-    def simplify(ex: BuilderT): BuilderT = simplifier.applySimplifyShallowToBuilderEx(ex)
-
-    set.cellType match {
-      case CellTFrom(SetT1(_)) =>
-        val pointersAndPredicates = state.arena.getHasPtr(set).map(ptr => ptr -> simplify(ptr.toSmt))
-        if (pointersAndPredicates.exists { case (_, pred) => simplifier.isTrueConst(pred) }) {
-          StaticallyNonEmpty
-        } else {
-          // remove the elements that are known to be non-members statically
-          val potentialMembers =
-            pointersAndPredicates.filterNot { case (_, pred) => simplifier.isFalseConst(pred) }.map(_._1.elem)
-          if (potentialMembers.isEmpty) {
-            StaticallyEmpty
-          } else {
-            // Pointer conditions are arena metadata and, in the Arrays encoding, may contain store expressions.
-            // Use actual set membership for the semantic emptiness predicate.
-            val noMember = potentialMembers.map(elem => tla.not(tla.selectInSet(elem.toBuilder, set.toBuilder)))
-            SymbolicallyEmptyWhen(simplify(tla.and(noMember: _*)))
-          }
-        }
-
-      // Every powerset contains the empty set. The built-in infinite sets are non-empty too.
-      case PowSetT(_) | InfSetT(_) =>
-        StaticallyNonEmpty
-
-      // [S -> T] is empty exactly when S is non-empty and T is empty.
-      case FinFunSetT(_, _) =>
-        val domEmptiness = setEmptiness(state, state.arena.getDom(set))
-        val cdmEmptiness = setEmptiness(state, state.arena.getCdm(set))
-        isFunSetEmpty(domEmptiness, cdmEmptiness)
-
-      case unexpected =>
-        throw new RewriterException(s"Expected a set cell, found: $unexpected", state.ex)
-    }
-  }
-
-  private def isFunSetEmpty(dom: SetEmptiness, cdm: SetEmptiness): SetEmptiness = {
-    def simplify(ex: BuilderT): BuilderT = simplifier.applySimplifyShallowToBuilderEx(ex)
-
-    (dom, cdm) match {
-      case (StaticallyEmpty, _) | (_, StaticallyNonEmpty) =>
-        StaticallyNonEmpty
-      case (StaticallyNonEmpty, StaticallyEmpty) =>
-        StaticallyEmpty
-      case (StaticallyNonEmpty, SymbolicallyEmptyWhen(cdmPred)) =>
-        SymbolicallyEmptyWhen(cdmPred)
-      case (SymbolicallyEmptyWhen(domPred), StaticallyEmpty) =>
-        SymbolicallyEmptyWhen(simplify(tla.not(domPred)))
-      case (SymbolicallyEmptyWhen(domPred), SymbolicallyEmptyWhen(cdmPred)) =>
-        SymbolicallyEmptyWhen(simplify(tla.and(tla.not(domPred), cdmPred)))
     }
   }
 

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/FunSetCtorRule.scala
@@ -7,7 +7,7 @@ import at.forsyte.apalache.tla.bmcmt.rules.support.SetEmptiness.StaticallyEmpty
 import at.forsyte.apalache.tla.bmcmt.types.FinFunSetT
 import at.forsyte.apalache.tla.lir._
 import at.forsyte.apalache.tla.lir.oper.TlaSetOper
-import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT, tlaU => tla}
+import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 
 /**
  * This rule constructs a cell for a function set [S -> T]. Nontrivial function sets stay unexpanded and point to S and

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/support/SetEmptiness.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/support/SetEmptiness.scala
@@ -4,7 +4,7 @@ import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
 import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, FinFunSetT, InfSetT, PowSetT}
 import at.forsyte.apalache.tla.bmcmt.{ArenaCell, RewriterException, SymbState}
 import at.forsyte.apalache.tla.lir.SetT1
-import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT, tlaU => tla}
+import at.forsyte.apalache.tla.types.{tlaU => tla, BuilderUT => BuilderT}
 
 /**
  * A predicate that holds exactly when the set is empty. When the membership can be predicted statically, the predicate

--- a/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/support/SetEmptiness.scala
+++ b/tla-bmcmt/src/main/scala/at/forsyte/apalache/tla/bmcmt/rules/support/SetEmptiness.scala
@@ -1,0 +1,85 @@
+package at.forsyte.apalache.tla.bmcmt.rules.support
+
+import at.forsyte.apalache.tla.bmcmt.rewriter.ConstSimplifierForSmt
+import at.forsyte.apalache.tla.bmcmt.types.{CellTFrom, FinFunSetT, InfSetT, PowSetT}
+import at.forsyte.apalache.tla.bmcmt.{ArenaCell, RewriterException, SymbState}
+import at.forsyte.apalache.tla.lir.SetT1
+import at.forsyte.apalache.tla.types.{BuilderUT => BuilderT, tlaU => tla}
+
+/**
+ * A predicate that holds exactly when the set is empty. When the membership can be predicted statically, the predicate
+ * is `tla.bool(true)` or `tla.bool(false)`.
+ */
+sealed trait SetEmptiness {
+  def predicate: BuilderT
+}
+
+object SetEmptiness {
+  case object StaticallyEmpty extends SetEmptiness {
+    override val predicate: BuilderT = tla.bool(true)
+  }
+
+  case object StaticallyNonEmpty extends SetEmptiness {
+    override val predicate: BuilderT = tla.bool(false)
+  }
+
+  case class SymbolicallyEmptyWhen(predicate: BuilderT) extends SetEmptiness
+
+  private val simplifier = new ConstSimplifierForSmt
+
+  private def simplify(ex: BuilderT): BuilderT = simplifier.applySimplifyShallowToBuilderEx(ex)
+
+  /**
+   * Classify set emptiness from its rewritten arena representation, without expanding lazy sets. Arena edges represent
+   * potential membership, so having edges does not in general imply that the set is nonempty.
+   */
+  def apply(state: SymbState, set: ArenaCell): SetEmptiness = {
+    set.cellType match {
+      case CellTFrom(SetT1(_)) =>
+        val pointersAndPredicates = state.arena.getHasPtr(set).map(ptr => ptr -> simplify(ptr.toSmt))
+        if (pointersAndPredicates.exists { case (_, pred) => simplifier.isTrueConst(pred) }) {
+          StaticallyNonEmpty
+        } else {
+          // Remove the elements that are known to be non-members statically.
+          val potentialMembers =
+            pointersAndPredicates.filterNot { case (_, pred) => simplifier.isFalseConst(pred) }.map(_._1.elem)
+          if (potentialMembers.isEmpty) {
+            StaticallyEmpty
+          } else {
+            // Pointer conditions are arena metadata and, in the Arrays encoding, may contain store expressions.
+            // Use actual set membership for the semantic emptiness predicate.
+            val noMember = potentialMembers.map(elem => tla.not(tla.selectInSet(elem.toBuilder, set.toBuilder)))
+            SymbolicallyEmptyWhen(simplify(tla.and(noMember: _*)))
+          }
+        }
+
+      // Every powerset contains the empty set. The built-in infinite sets are non-empty too.
+      case PowSetT(_) | InfSetT(_) =>
+        StaticallyNonEmpty
+
+      // [S -> T] is empty exactly when S is non-empty and T is empty.
+      case FinFunSetT(_, _) =>
+        val domEmptiness = apply(state, state.arena.getDom(set))
+        val cdmEmptiness = apply(state, state.arena.getCdm(set))
+        isFunSetEmpty(domEmptiness, cdmEmptiness)
+
+      case unexpected =>
+        throw new RewriterException(s"Expected a set cell, found: $unexpected", state.ex)
+    }
+  }
+
+  private def isFunSetEmpty(dom: SetEmptiness, cdm: SetEmptiness): SetEmptiness = {
+    (dom, cdm) match {
+      case (StaticallyEmpty, _) | (_, StaticallyNonEmpty) =>
+        StaticallyNonEmpty
+      case (StaticallyNonEmpty, StaticallyEmpty) =>
+        StaticallyEmpty
+      case (StaticallyNonEmpty, SymbolicallyEmptyWhen(cdmPred)) =>
+        SymbolicallyEmptyWhen(cdmPred)
+      case (SymbolicallyEmptyWhen(domPred), StaticallyEmpty) =>
+        SymbolicallyEmptyWhen(simplify(tla.not(domPred)))
+      case (SymbolicallyEmptyWhen(domPred), SymbolicallyEmptyWhen(cdmPred)) =>
+        SymbolicallyEmptyWhen(simplify(tla.and(tla.not(domPred), cdmPred)))
+    }
+  }
+}

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -10,6 +10,200 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
   val i_to_B: TlaType1 = FunT1(IntT1, SetT1(BoolT1))
   val i_to_i_to_B: TlaType1 = FunT1(IntT1, FunT1(IntT1, SetT1(BoolT1)))
 
+  private def assertForBothGuardValues(rewriter: SymbStateRewriter, state: SymbState, guard: ArenaCell): Unit = {
+    rewriter.push()
+    val nextState = rewriter.rewriteUntilDone(state)
+    for (value <- Seq(false, true)) {
+      rewriter.push()
+      rewriter.solverContext.assertGroundExpr(tla.eql(guard.toBuilder, tla.bool(value)))
+      assertTlaExAndRestore(rewriter, nextState)
+      rewriter.pop()
+    }
+    rewriter.pop()
+  }
+
+  // Keep all four operands symbolic so constructor normalization cannot hide the lazy-equality bug.
+  for (sameDomain <- Seq(false, true); sameCodomain <- Seq(false, true)) {
+    test(s"function-set equality (#3477): symbolic operands, sameDomain=$sameDomain, sameCodomain=$sameCodomain") {
+      rewriterType: SMTEncoding =>
+        val rewriter = create(rewriterType)
+        var state = new SymbState(tla.bool(true), arena, Binding())
+        val guards = (0 until 4).map { _ =>
+          state = state.updateArena(_.appendCell(BoolT1))
+          state.arena.topCell
+        }
+
+        def operand(index: Int, value: Int): TBuilderInstruction =
+          tla.ite(guards(index).toBuilder, tla.enumSet(tla.int(value)), tla.emptySet(IntT1))
+
+        state = rewriter.rewriteUntilDone(state.setRex(tla.funSet(operand(0, 1), operand(1, 3))))
+        val left = state.asCell
+        state = rewriter.rewriteUntilDone(state.setRex(tla.funSet(operand(2, if (sameDomain) 1 else 2),
+          operand(3, if (sameCodomain) 3 else 4))))
+        val right = state.asCell
+        assert(left.cellType.isInstanceOf[FinFunSetT])
+        assert(right.cellType.isInstanceOf[FinFunSetT])
+
+        // Repeat after pop, reversing the operands, to exercise equality-cache scoping and symmetry.
+        for ((a, b) <- Seq((left, right), (right, left))) {
+          rewriter.push()
+          val eqState = rewriter.rewriteUntilDone(state.setRex(tla.eql(a.toBuilder, b.toBuilder)))
+          for (mask <- 0 until 16) {
+            val present = guards.indices.map(i => (mask & (1 << i)) != 0)
+            val d1 = present(0)
+            val c1 = present(1)
+            val d2 = present(2)
+            val c2 = present(3)
+            val expected =
+              (!d1 && !d2) || (d1 && d2 && !c1 && !c2) ||
+                (d1 && d2 && c1 && c2 && sameDomain && sameCodomain)
+            rewriter.push()
+            guards.zip(present).foreach { case (guard, value) =>
+              rewriter.solverContext.assertGroundExpr(tla.eql(guard.toBuilder, tla.bool(value)))
+            }
+            withClue(s"membership mask=$mask: ") {
+              // Check consistency as well as validity: an inconsistent encoding must not pass vacuously.
+              assertTlaExAndRestore(rewriter, eqState.setRex(tla.eql(tla.unchecked(eqState.ex), tla.bool(expected))))
+            }
+            rewriter.pop()
+          }
+          rewriter.pop()
+        }
+    }
+  }
+
+  for (filterDomain <- Seq(false, true)) {
+    test(s"function-set equality (#3477): filtered operand, filterDomain=$filterDomain") { rewriterType: SMTEncoding =>
+      val rewriter = create(rewriterType)
+      val withGuard = arena.appendCell(BoolT1)
+      val guard = withGuard.topCell
+      val filtered = tla.filter(tla.name("x", IntT1), tla.enumSet(tla.int(1), tla.int(2)),
+        tla.and(guard.toBuilder, tla.eql(tla.name("x", IntT1), tla.int(1))))
+      var state = rewriter.rewriteUntilDone(new SymbState(filtered, withGuard, Binding()))
+      val set = state.asCell
+      assert(state.arena.getHas(set).nonEmpty)
+
+      def funSet(value: Int): TBuilderInstruction =
+        if (filterDomain) tla.funSet(set.toBuilder, tla.enumSet(tla.int(value)))
+        else tla.funSet(tla.enumSet(tla.int(value)), set.toBuilder)
+
+      state = rewriter.rewriteUntilDone(state.setRex(funSet(3)))
+      val left = state.asCell
+      state = rewriter.rewriteUntilDone(state.setRex(funSet(4)))
+      val right = state.asCell
+      assert(left.cellType.isInstanceOf[FinFunSetT])
+      assert(right.cellType.isInstanceOf[FinFunSetT])
+      val eq = tla.eql(left.toBuilder, right.toBuilder)
+      assertForBothGuardValues(rewriter, state.setRex(tla.eql(eq, tla.not(guard.toBuilder))), guard)
+    }
+  }
+
+  for (sameOuterDomain <- Seq(false, true)) {
+    test(s"function-set equality (#3477): nested codomains, sameOuterDomain=$sameOuterDomain") {
+      rewriterType: SMTEncoding =>
+        val rewriter = create(rewriterType)
+        val withGuard = arena.appendCell(BoolT1)
+        val guard = withGuard.topCell
+        val codomain = tla.ite(guard.toBuilder, tla.emptySet(IntT1), tla.enumSet(tla.int(3)))
+        val leftEx = tla.funSet(tla.enumSet(tla.int(0)), tla.funSet(tla.enumSet(tla.int(1)), codomain))
+        val rightEx = tla
+          .funSet(tla.enumSet(tla.int(if (sameOuterDomain) 0 else 10)), tla.funSet(tla.enumSet(tla.int(2)), codomain))
+        var state = rewriter.rewriteUntilDone(new SymbState(leftEx, withGuard, Binding()))
+        val left = state.asCell
+        state = rewriter.rewriteUntilDone(state.setRex(rightEx))
+        val right = state.asCell
+        assert(state.arena.getCdm(left).cellType.isInstanceOf[FinFunSetT])
+        assert(state.arena.getCdm(right).cellType.isInstanceOf[FinFunSetT])
+        val eq = tla.eql(left.toBuilder, right.toBuilder)
+        assertForBothGuardValues(rewriter, state.setRex(tla.eql(eq, guard.toBuilder)), guard)
+    }
+  }
+
+  test("function-set equality (#3477): mixed conditional empty-function singleton and lazy set") {
+    rewriterType: SMTEncoding =>
+      val rewriter = create(rewriterType)
+      var state = new SymbState(tla.bool(true), arena, Binding())
+      val guards = (0 until 3).map { _ =>
+        state = state.updateArena(_.appendCell(BoolT1))
+        state.arena.topCell
+      }
+
+      def operand(index: Int, value: Int): TBuilderInstruction =
+        tla.ite(guards(index).toBuilder, tla.emptySet(IntT1), tla.enumSet(tla.int(value)))
+
+      state = rewriter.rewriteUntilDone(state.setRex(tla.funSet(operand(0, 1), tla.emptySet(IntT1))))
+      val ordinary = state.asCell
+      state = rewriter.rewriteUntilDone(state.setRex(tla.funSet(operand(1, 2), operand(2, 3))))
+      val lazySet = state.asCell
+      assert(ordinary.cellType == CellTFrom(SetT1(FunT1(IntT1, IntT1))))
+      assert(lazySet.cellType.isInstanceOf[FinFunSetT])
+      for ((left, right) <- Seq((ordinary, lazySet), (lazySet, ordinary))) {
+        rewriter.push()
+        val eqState = rewriter.rewriteUntilDone(state.setRex(tla.eql(left.toBuilder, right.toBuilder)))
+        for (mask <- 0 until 8) {
+          val empty = guards.indices.map(i => (mask & (1 << i)) != 0)
+          val expected = (empty(0) && empty(1)) || (!empty(0) && !empty(1) && empty(2))
+          rewriter.push()
+          guards.zip(empty).foreach { case (guard, value) =>
+            rewriter.solverContext.assertGroundExpr(tla.eql(guard.toBuilder, tla.bool(value)))
+          }
+          assertTlaExAndRestore(rewriter, eqState.setRex(tla.eql(tla.unchecked(eqState.ex), tla.bool(expected))))
+          rewriter.pop()
+        }
+        rewriter.pop()
+      }
+  }
+
+  test("function-set equality (#3477): nested mixed representations") { rewriterType: SMTEncoding =>
+    val rewriter = create(rewriterType)
+    val withGuard = arena.appendCell(BoolT1)
+    val guard = withGuard.topCell
+    val domain = tla.ite(guard.toBuilder, tla.emptySet(IntT1), tla.enumSet(tla.int(1)))
+    val left = tla.funSet(tla.enumSet(tla.int(0)), tla.funSet(domain, tla.emptySet(IntT1)))
+    val right = tla.funSet(tla.enumSet(tla.int(0)), tla.funSet(domain, tla.enumSet(tla.int(2))))
+    val assertions = tla.and(
+      tla.eql(tla.eql(left, right), guard.toBuilder),
+      tla.eql(tla.eql(tla.enumSet(left), tla.enumSet(right)), guard.toBuilder),
+    )
+    val state = new SymbState(assertions, withGuard, Binding())
+    assertForBothGuardValues(rewriter, state, guard)
+  }
+
+  test("function-set equality (#3477): reject general mixed enumerated function sets") { rewriterType: SMTEncoding =>
+    val domain = tla.enumSet(tla.int(1))
+    val fun = tla.funDef(tla.int(2), tla.name("x", IntT1) -> domain)
+    val equality = tla.eql(tla.funSet(domain, tla.enumSet(tla.int(2))), tla.enumSet(fun))
+    val rewriter = create(rewriterType)
+    val error = intercept[RewriterException] {
+      rewriter.rewriteUntilDone(new SymbState(equality, arena, Binding()))
+    }
+    assert(error.getMessage.contains("enumerated set of nonempty-domain functions"))
+  }
+
+  test("function-set equality (#3477): reject unsupported lazy operand equality") { rewriterType: SMTEncoding =>
+    val domain = tla.enumSet(tla.int(0))
+    val left = tla.funSet(domain, tla.powSet(tla.enumSet(tla.int(1))))
+    val right = tla.funSet(domain, tla.powSet(tla.enumSet(tla.int(2))))
+    val rewriter = create(rewriterType)
+    // Unexpanded powersets have no ordinary membership edges. Treating them as enumerated sets would equate them.
+    intercept[CheckerException] {
+      rewriter.rewriteUntilDone(new SymbState(tla.eql(left, right), arena, Binding()))
+    }
+  }
+
+  test("function-set equality (#3477): literal degenerate sets") { rewriterType: SMTEncoding =>
+    val empty = tla.emptySet(IntT1)
+    val one = tla.enumSet(tla.int(1))
+    val two = tla.enumSet(tla.int(2))
+    val assertions = tla.and(
+      tla.eql(tla.funSet(empty, one), tla.funSet(empty, two)),
+      tla.eql(tla.funSet(one, empty), tla.funSet(two, empty)),
+      tla.not(tla.eql(tla.funSet(empty, empty), tla.funSet(one, empty))),
+      tla.not(tla.eql(tla.funSet(one, one), tla.funSet(one, two))),
+    )
+    assertTlaExAndRestore(create(rewriterType), new SymbState(assertions, arena, Binding()))
+  }
+
   test("[{} -> {}] is a singleton containing the empty function") { rewriterType: SMTEncoding =>
     val funSet = tla.funSet(tla.emptySet(IntT1), tla.emptySet(IntT1))
     val state = new SymbState(funSet, arena, Binding())

--- a/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
+++ b/tla-bmcmt/src/test/scala/at/forsyte/apalache/tla/bmcmt/TestSymbStateRewriterFunSet.scala
@@ -39,7 +39,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
         state = rewriter.rewriteUntilDone(state.setRex(tla.funSet(operand(0, 1), operand(1, 3))))
         val left = state.asCell
         state = rewriter.rewriteUntilDone(state.setRex(tla.funSet(operand(2, if (sameDomain) 1 else 2),
-          operand(3, if (sameCodomain) 3 else 4))))
+                    operand(3, if (sameCodomain) 3 else 4))))
         val right = state.asCell
         assert(left.cellType.isInstanceOf[FinFunSetT])
         assert(right.cellType.isInstanceOf[FinFunSetT])
@@ -78,7 +78,7 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
       val withGuard = arena.appendCell(BoolT1)
       val guard = withGuard.topCell
       val filtered = tla.filter(tla.name("x", IntT1), tla.enumSet(tla.int(1), tla.int(2)),
-        tla.and(guard.toBuilder, tla.eql(tla.name("x", IntT1), tla.int(1))))
+          tla.and(guard.toBuilder, tla.eql(tla.name("x", IntT1), tla.int(1))))
       var state = rewriter.rewriteUntilDone(new SymbState(filtered, withGuard, Binding()))
       val set = state.asCell
       assert(state.arena.getHas(set).nonEmpty)
@@ -162,8 +162,8 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
     val left = tla.funSet(tla.enumSet(tla.int(0)), tla.funSet(domain, tla.emptySet(IntT1)))
     val right = tla.funSet(tla.enumSet(tla.int(0)), tla.funSet(domain, tla.enumSet(tla.int(2))))
     val assertions = tla.and(
-      tla.eql(tla.eql(left, right), guard.toBuilder),
-      tla.eql(tla.eql(tla.enumSet(left), tla.enumSet(right)), guard.toBuilder),
+        tla.eql(tla.eql(left, right), guard.toBuilder),
+        tla.eql(tla.eql(tla.enumSet(left), tla.enumSet(right)), guard.toBuilder),
     )
     val state = new SymbState(assertions, withGuard, Binding())
     assertForBothGuardValues(rewriter, state, guard)
@@ -196,10 +196,10 @@ trait TestSymbStateRewriterFunSet extends RewriterBase {
     val one = tla.enumSet(tla.int(1))
     val two = tla.enumSet(tla.int(2))
     val assertions = tla.and(
-      tla.eql(tla.funSet(empty, one), tla.funSet(empty, two)),
-      tla.eql(tla.funSet(one, empty), tla.funSet(two, empty)),
-      tla.not(tla.eql(tla.funSet(empty, empty), tla.funSet(one, empty))),
-      tla.not(tla.eql(tla.funSet(one, one), tla.funSet(one, two))),
+        tla.eql(tla.funSet(empty, one), tla.funSet(empty, two)),
+        tla.eql(tla.funSet(one, empty), tla.funSet(two, empty)),
+        tla.not(tla.eql(tla.funSet(empty, empty), tla.funSet(one, empty))),
+        tla.not(tla.eql(tla.funSet(one, one), tla.funSet(one, two))),
     )
     assertTlaExAndRestore(create(rewriterType), new SymbState(assertions, arena, Binding()))
   }


### PR DESCRIPTION
Closes #3477. As we realized in #3477, equality over function sets over empty domains/co-domains was not implemented correctly. This PR fixes lazy equality over function sets, taking care of the empty set cases. The general case of comparing function sets and sets of functions is still not implemented.

Implemented with gpt-6-astra.

- [x] I have read the section on [creating a pull request][]
- [x] I have read the [AI Policy][]
- [x] Tests added for any new code
- [x] Ran `make fmt-fix` (or had formatting run automatically on all files edited)
- [x] [Entries added to `./unreleased/`][changelog format] for any new functionality

[changelog format]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#how-to-record-a-change
[creating a pull request]: https://github.com/apalache-mc/apalache/blob/main/CONTRIBUTING.md#making-a-pull-request
[AI Policy]: https://github.com/apalache-mc/apalache/blob/main/AI_POLICY.md